### PR TITLE
bro-pkg.meta filename access via the Python API

### DIFF
--- a/bro-pkg
+++ b/bro-pkg
@@ -1505,8 +1505,12 @@ def cmd_info(manager, args, config):
                     print('\t\t{} = {}'.format(key, value))
 
         if args.json:
+            if info.metadata_file:
+                pkginfo[name]['metadata_file'] = info.metadata_file
             pkginfo[name]['metadata'][info.metadata_version] = dict()
         else:
+            if info.metadata_file:
+                print('\tmetadata file: {}'.format(info.metadata_file))
             print('\tmetadata (from version "{}"):'.format(
                 info.metadata_version))
 
@@ -1533,6 +1537,8 @@ def cmd_info(manager, args, config):
                                          vers,
                                          prefer_installed=(args.nolocal != True))
                     pkginfo[name]['metadata'][info2.metadata_version] = dict()
+                    if info2.metadata_file:
+                        pkginfo[name]['metadata_file'] = info2.metadata_file
                     _fill_metadata_version(
                         pkginfo[name]['metadata'][info2.metadata_version],
                         info2.metadata)

--- a/bropkg/manager.py
+++ b/bropkg/manager.py
@@ -2360,10 +2360,12 @@ def _info_from_clone(clone, package, status, version):
     if invalid_reason:
         return PackageInfo(package=package, invalid_reason=invalid_reason,
                            status=status, versions=versions,
-                           metadata_version=version, version_type=version_type)
+                           metadata_version=version, version_type=version_type,
+                           metadata_file=metadata_file)
 
     metadata = _get_package_metadata(metadata_parser)
 
     return PackageInfo(package=package, invalid_reason=invalid_reason,
                        status=status, metadata=metadata, versions=versions,
-                       metadata_version=version, version_type=version_type)
+                       metadata_version=version, version_type=version_type,
+                       metadata_file=metadata_file)

--- a/bropkg/package.py
+++ b/bropkg/package.py
@@ -216,11 +216,17 @@ class PackageInfo(object):
             version tag, a branch, or a specific commit hash.
 
         invalid_reason (str): this attribute is set when there is a problem
-            with gathering package information and explains what went wrong
+            with gathering package information and explains what went wrong.
+
+        metadata_file: the absolute path to bro-pkg.meta for this
+            package.  Use this if you'd like to parse the metadata
+            yourself. May not be defined, in which case the value is
+            None.
     """
 
     def __init__(self, package=None, status=None, metadata=None, versions=None,
-                 metadata_version='', invalid_reason='', version_type=''):
+                 metadata_version='', invalid_reason='', version_type='',
+                 metadata_file=None):
         self.package = package
         self.status = status
         self.metadata = {} if metadata is None else metadata
@@ -228,6 +234,7 @@ class PackageInfo(object):
         self.metadata_version = metadata_version
         self.version_type = version_type
         self.invalid_reason = invalid_reason
+        self.metadata_file = metadata_file
 
     def aliases(self):
         """Return a list of package name aliases.


### PR DESCRIPTION
This tracks the absolute file name to bro-pkg.meta in PackageInfo instances, so that folks who want to parse the metadata themselves can access it reliably.