### PR TITLE
When loading/unloading a Zeek package, also enable/disable any plugin

### DIFF
--- a/testing/tests/plugin
+++ b/testing/tests/plugin
@@ -7,6 +7,20 @@
 # @TEST-EXEC: btest-diff plugins/packages/rot13/__bro_plugin__ 
 # @TEST-EXEC: btest-diff scripts/packages/rot13/__load__.zeek
 
+# Unloading the package should also disable the plugin, which we
+# detect via the renamed __bro_plugin__ magic file.
+# @TEST-EXEC: zkg unload rot13
+
+# @TEST-EXEC: test ! -f plugins/packages/rot13/__bro_plugin__
+# @TEST-EXEC: btest-diff plugins/packages/rot13/__bro_plugin__.disabled
+
+# (Re-)loading the package should also (re-)enable the plugin.
+# @TEST-EXEC: zkg load rot13
+
+# @TEST-EXEC: test ! -f plugins/packages/rot13/__bro_plugin__.disabled
+# @TEST-EXEC: cp plugins/packages/rot13/__bro_plugin__  __bro_plugin__.after_enabling
+# @TEST-EXEC: btest-diff __bro_plugin__.after_enabling
+
 echo "$(pwd)/packages/rot13" >> sources/one/bob/zkg.index
 cd sources/one
 git commit -am 'add rot13 package'

--- a/zeekpkg/package.py
+++ b/zeekpkg/package.py
@@ -19,6 +19,9 @@ TRACKING_METHOD_VERSION = 'version'
 TRACKING_METHOD_BRANCH = 'branch'
 TRACKING_METHOD_COMMIT = 'commit'
 
+PLUGIN_MAGIC_FILE = '__bro_plugin__'
+PLUGIN_MAGIC_FILE_DISABLED = '__bro_plugin__.disabled'
+
 def name_from_path(path):
     """Returns the name of a package given a path to its git repository."""
     return canonical_url(path).split('/')[-1]


### PR DESCRIPTION
Jon, could you let me know if this looks okay to you?

This patch does this via renaming of the __bro_plugin__ magic file that Zeek looks for when scanning ZEEK_PLUGIN_PATH. To disable a plugin, zkg renames the file to __bro_plugin__.disabled, and renames that file back to __bro_plugin__ when enabling.

I've tweaked the most relevant btest to verify the renaming. It currently does not invoke Zeek itself to verify presence/absence of the plugin in the -N output, but I've tested manually and verified that the plugin doesn't get loaded when the magic file is renamed.