### PR TITLE
Bugfix: incorrect arguments to Manager.has_plugin()

### DIFF
--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1022,7 +1022,7 @@ class Manager(object):
 
         if (not os.path.exists(pkg_load_script) and
             not os.path.exists(pkg_load_fallback) and
-            not self.has_plugin(self, ipkg)):
+            not self.has_plugin(ipkg)):
             LOG.debug('loading "%s": %s not found and package has no plugin',
                       pkg_path, pkg_load_script)
             return 'no __load__.zeek within package script_dir and no plugin included'


### PR DESCRIPTION
Sorry about this one, Jon! I never actually hit a case where there's no script content in a plugin, but @0xxon did. :) The problem looks like this:

```+    Traceback (most recent call last):
+      File “bro-pkg”, line 2149, in <module>
+        main()
+      File “bro-pkg”, line 2145, in main
+        args.run_cmd(manager, args, config)
+      File “bro-pkg”, line 797, in cmd_unbundle
+        load_error = manager.load(name)
+      File “manager.py”, line 996, in load
+        not self.has_plugin(self, ipkg)):
+    TypeError: has_plugin() takes 2 positional arguments but 3 were given```