### PR TITLE
Do not expect SHELL in environment

### DIFF
--- a/zkg
+++ b/zkg
@@ -1748,7 +1748,7 @@ def cmd_env(manager, args, config, configfile):
     zeekpaths.append(manager.zeekpath())
     pluginpaths.append(manager.zeek_plugin_path())
 
-    if os.environ['SHELL'].endswith('csh'):
+    if os.environ.get('SHELL', '').endswith('csh'):
         print(u'setenv BROPATH {}'.format(':'.join(zeekpaths)))
         print(u'setenv BRO_PLUGIN_PATH {}'.format(':'.join(pluginpaths)))
         print(u'setenv ZEEKPATH {}'.format(':'.join(zeekpaths)))


### PR DESCRIPTION
When running `zkg env` inside a container, the following trace is observed:

    Traceback (most recent call last):
      File "/usr/local/bin/zkg", line 2226, in <module>
        main()
      File "/usr/local/bin/zkg", line 2222, in main
        args.run_cmd(manager, args, config, configfile)
      File "/usr/local/bin/zkg", line 1751, in cmd_env
        if os.environ['SHELL'].endswith('csh'):
      File "/usr/local/lib/python3.8/os.py", line 673, in __getitem__
        raise KeyError(key) from None
    KeyError: 'SHELL'

Minimal Dockerfile to reproduce:

    FROM python:3.8
    RUN pip3 install zkg
    RUN zkg env