### PR TITLE
Introduce basic package name validation

### DIFF
--- a/testing/baselines/tests.install-invalid/output
+++ b/testing/baselines/tests.install-invalid/output
@@ -1,0 +1,2 @@
+error: invalid package ".": Package name ' fronting-whitespace' is not valid.
+error: invalid package ".": Package name 'trailing-whitespace ' is not valid.

--- a/testing/baselines/tests.install-reserved/output
+++ b/testing/baselines/tests.install-reserved/output
@@ -1,0 +1,1 @@
+error: invalid package ".": Package name 'packages' is not valid.

--- a/testing/tests/install-invalid
+++ b/testing/tests/install-invalid
@@ -1,0 +1,12 @@
+# Test invalid package names
+# @TEST-EXEC: ! bash %INPUT 2>output
+# @TEST-EXEC: btest-diff output
+
+CONFIG=$(pwd)/config
+mkdir -p invalid
+
+cp -R ./packages/bar ./invalid/\ fronting-whitespace
+(cd ./invalid/\ fronting-whitespace && zkg --config=$CONFIG install --force .)
+
+cp -R ./packages/bar './invalid/trailing-whitespace '
+(cd './invalid/trailing-whitespace ' && zkg --config=$CONFIG install --force . )

--- a/testing/tests/install-reserved
+++ b/testing/tests/install-reserved
@@ -1,0 +1,9 @@
+# Rename a package to live in a directory called "packages"
+# @TEST-EXEC: ! bash %INPUT 2>output
+# @TEST-EXEC: btest-diff output
+
+CONFIG=$(pwd)/config
+mkdir -p reserved
+cp -R ./packages/bar ./reserved/packages
+
+cd ./reserved/packages && zkg --config=$CONFIG install --force .

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -61,6 +61,7 @@ from .package import (
     aliases,
     user_vars,
     canonical_url,
+    is_valid_name as is_valid_package_name,
     Package,
     PackageInfo,
     PackageStatus,
@@ -1167,6 +1168,11 @@ class Manager(object):
             A :class:`.package.PackageInfo` object.
         """
         pkg_path = canonical_url(pkg_path)
+        name = name_from_path(pkg_path)
+        if not is_valid_package_name(name):
+            reason = 'Package name {!r} is not valid.'.format(name, pkg_path)
+            return PackageInfo(Package(git_url=pkg_path), invalid_reason=reason)
+
         LOG.debug('getting info on "%s"', pkg_path)
         ipkg = self.find_installed_package(pkg_path)
 

--- a/zeekpkg/package.py
+++ b/zeekpkg/package.py
@@ -34,6 +34,16 @@ def canonical_url(path):
     return url
 
 
+def is_valid_name(name):
+    """Returns True if name is a valid package name, else False."""
+    if name != name.strip():  # No fronting/trailing whitespace
+        return False
+    if name in ("package", "packages"):
+        return False
+
+    return True
+
+
 def aliases(metadata_dict):
     """Return a list of package aliases found in metadata's 'aliases' field."""
     if 'aliases' not in metadata_dict:


### PR DESCRIPTION
Hey,

I tried to install a package from `/packages` today (docker volume mount, long story, ;-) ).

Anyway, it fails:
```
root@aee775ebc7e9:/packages# zkg install --force .
Running unit tests for "/packages"
error: failed to run tests for /packages: could not create symlink at /root/.zkg/testing/packages/scripts/packages: FileExistsError: [Errno 17] File exists: 'packages/packages' -> '/root/.zkg/testing/packages/scripts/packages'
```

This MR includes a test to reproduce the issue only.

Any thoughts on how to "react" here? It seems the pragmatic to just respond with a message saying `packages` is reserved? And probably add `package` as well?

Or just too esoteric to be dealt with?