### PR TITLE
Accept Y as yes, too.

### DIFF
--- a/zkg
+++ b/zkg
@@ -63,7 +63,7 @@ def confirmation_prompt(prompt, default_to_yes=True):
     if not choice:
         return default_to_yes
 
-    if choice in yes:
+    if choice.lower() in yes:
         return True
 
     print('Abort.')


### PR DESCRIPTION
I've just ran into this. I should've just hit enter, or typed `y`, but
aborting on `Y` was very unexpected (apt-get allows `Y`).

    $ zkg --config ./config bundle --manifest ./manifest -- bundle.tar.gz
    ...
    Proceed? [Y/n] Y
    Abort.

