### PR TITLE
Add runtime dependency checks for zkg

### DIFF
--- a/testing/baselines/tests.runtime-test/loaded.out
+++ b/testing/baselines/tests.runtime-test/loaded.out
@@ -1,29 +1,27 @@
 Install grault
-Installed "one/bob/grault" (1.0.0)
-Loaded "one/bob/grault"
 Installed "one/bob/corge" (1.0.0)
 Loaded "one/bob/corge"
+Installed "one/bob/grault" (1.0.0)
+Loaded "one/bob/grault"
 Unload grault
 The following installed packages were additionally unloaded to satisfy runtime dependencies for "one/bob/grault".
   corge
 
 Unloaded "one/bob/grault"
 Install foo
-Installed "one/alice/foo" (master)
-Loaded "one/alice/foo"
-Installed "one/alice/baz" (1.0.0)
-Loaded "one/alice/baz"
 Installed "one/alice/bar" (1.0.0)
 Loaded "one/alice/bar"
+Installed "one/alice/baz" (1.0.0)
+Loaded "one/alice/baz"
+Installed "one/alice/foo" (master)
+Loaded "one/alice/foo"
 The following installed packages were additionally loaded to satisfy runtime dependencies
   corge
   grault
 
 Unload grault
-Following packages are dependent on "one/bob/grault" and are currently in use.
-  baz
-  bar
-  foo
+Following packages could not be unloaded.
+  grault: Package is in use by other packages --- "bar", "baz", "foo".
 
 Failed unloading "one/bob/grault"
 Unload foo

--- a/testing/baselines/tests.runtime-test/loaded.out
+++ b/testing/baselines/tests.runtime-test/loaded.out
@@ -1,0 +1,64 @@
+
+Install grault
+Installed "one/bob/grault" (1.0.0)
+Loaded "one/bob/grault"
+Installed "one/bob/corge" (1.0.0)
+Loaded "one/bob/corge"
+
+Unload grault
+The following installed packages were additionally unloaded to satisfy runtime dependencies for "one/bob/grault".
+  corge
+
+Unloaded "one/bob/grault"
+
+Install foo
+Installed "one/alice/foo" (master)
+Loaded "one/alice/foo"
+Installed "one/alice/baz" (1.0.0)
+Loaded "one/alice/baz"
+Installed "one/alice/bar" (1.0.0)
+Loaded "one/alice/bar"
+The following installed packages were additionally loaded to satisfy runtime dependencies
+  corge
+  grault
+
+
+Unload grault
+Following packages are dependent on "one/bob/grault" and are currently in use.
+  baz
+  bar
+  foo
+
+Failed unloading "one/bob/grault"
+
+Unload foo
+The following installed packages were additionally unloaded to satisfy runtime dependencies for "one/alice/foo".
+  bar
+  baz
+  corge
+  grault
+
+Unloaded "one/alice/foo"
+
+Load foo
+The following installed packages were additionally loaded to satisfy runtime dependencies for "one/alice/foo".
+  bar
+  baz
+  corge
+  grault
+
+Loaded "one/alice/foo"
+
+Remove grault
+The following packages depend on "one/bob/grault" and removing it will BREAK them.
+  baz
+  bar
+  foo
+
+The following installed packages (or more) will be unloaded as well.
+  bar
+  foo
+  baz
+  corge
+
+Removed "one/bob/grault"

--- a/testing/baselines/tests.runtime-test/loaded.out
+++ b/testing/baselines/tests.runtime-test/loaded.out
@@ -1,16 +1,13 @@
-
 Install grault
 Installed "one/bob/grault" (1.0.0)
 Loaded "one/bob/grault"
 Installed "one/bob/corge" (1.0.0)
 Loaded "one/bob/corge"
-
 Unload grault
 The following installed packages were additionally unloaded to satisfy runtime dependencies for "one/bob/grault".
   corge
 
 Unloaded "one/bob/grault"
-
 Install foo
 Installed "one/alice/foo" (master)
 Loaded "one/alice/foo"
@@ -22,7 +19,6 @@ The following installed packages were additionally loaded to satisfy runtime dep
   corge
   grault
 
-
 Unload grault
 Following packages are dependent on "one/bob/grault" and are currently in use.
   baz
@@ -30,7 +26,6 @@ Following packages are dependent on "one/bob/grault" and are currently in use.
   foo
 
 Failed unloading "one/bob/grault"
-
 Unload foo
 The following installed packages were additionally unloaded to satisfy runtime dependencies for "one/alice/foo".
   bar
@@ -39,7 +34,6 @@ The following installed packages were additionally unloaded to satisfy runtime d
   grault
 
 Unloaded "one/alice/foo"
-
 Load foo
 The following installed packages were additionally loaded to satisfy runtime dependencies for "one/alice/foo".
   bar
@@ -48,7 +42,6 @@ The following installed packages were additionally loaded to satisfy runtime dep
   grault
 
 Loaded "one/alice/foo"
-
 Remove grault
 The following packages depend on "one/bob/grault" and removing it will BREAK them.
   bar

--- a/testing/baselines/tests.runtime-test/loaded.out
+++ b/testing/baselines/tests.runtime-test/loaded.out
@@ -51,14 +51,14 @@ Loaded "one/alice/foo"
 
 Remove grault
 The following packages depend on "one/bob/grault" and removing it will BREAK them.
-  baz
   bar
+  baz
   foo
 
 The following installed packages (or more) will be unloaded as well.
   bar
-  foo
   baz
   corge
+  foo
 
 Removed "one/bob/grault"

--- a/testing/baselines/tests.runtime-test/loaded.out
+++ b/testing/baselines/tests.runtime-test/loaded.out
@@ -52,4 +52,26 @@ The following installed packages (or more) will be unloaded as well.
   corge
   foo
 
+Following packages could not be unloaded.
+  bar: Package is in use by other packages --- "foo".
+
+Failed unloading "bar"
+Following packages could not be unloaded.
+  baz: Package is in use by other packages --- "bar", "foo".
+
+Failed unloading "baz"
+The following installed packages were additionally unloaded to satisfy runtime dependencies for "foo".
+  bar
+  baz
+  corge
+  grault
+
+Unloaded "foo"
+The following installed packages were additionally unloaded to satisfy runtime dependencies for "one/bob/grault".
+  bar
+  baz
+  corge
+  foo
+
+Unloaded "one/bob/grault"
 Removed "one/bob/grault"

--- a/testing/tests/runtime-test
+++ b/testing/tests/runtime-test
@@ -1,0 +1,46 @@
+# @TEST-EXEC: bash %INPUT
+
+# @TEST-EXEC: echo '\nInstall grault' > loaded.out
+# @TEST-EXEC: zkg -r install grault --force >> loaded.out
+
+# @TEST-EXEC: echo '\nUnload grault' >> loaded.out
+# @TEST-EXEC: zkg -r unload grault >> loaded.out
+
+# @TEST-EXEC: echo '\nInstall foo' >> loaded.out
+# @TEST-EXEC: zkg -r install foo --force >> loaded.out
+
+# @TEST-EXEC: echo '\nUnload grault' >> loaded.out
+# @TEST-EXEC-FAIL: zkg -r unload grault >> loaded.out
+
+# @TEST-EXEC: echo '\nUnload foo' >> loaded.out
+# @TEST-EXEC: zkg -r unload foo >> loaded.out
+
+# @TEST-EXEC: echo '\nLoad foo' >> loaded.out
+# @TEST-EXEC: zkg -r load foo >> loaded.out
+
+# @TEST-EXEC: echo '\nRemove grault' >> loaded.out
+# @TEST-EXEC: zkg -r remove grault --force >> loaded.out
+
+# @TEST-EXEC: btest-diff loaded.out
+
+cd packages/foo
+echo 'depends = bar *' >> zkg.meta
+git commit -am 'new stuff'
+
+cd ../bar
+echo 'depends = baz >=1.0.0' >> zkg.meta
+git commit -am 'new stuff'
+git tag -a 1.0.0 -m 1.0.0
+
+cd ../baz
+echo 'depends = grault ==1.0.0' >> zkg.meta
+git commit -am 'new stuff'
+git tag -a 1.0.0 -m 1.0.0
+
+cd ../grault
+echo 'depends = corge ==1.0.0' >> zkg.meta
+git commit -am 'new stuff'
+git tag -a 1.0.0 -m 1.0.0
+
+cd ../corge
+git tag -a 1.0.0 -m 1.0.0

--- a/testing/tests/runtime-test
+++ b/testing/tests/runtime-test
@@ -1,25 +1,25 @@
 # @TEST-EXEC: bash %INPUT
 
 # @TEST-EXEC: echo '\nInstall grault' > loaded.out
-# @TEST-EXEC: zkg -r install grault --force >> loaded.out
+# @TEST-EXEC: zkg install grault --force >> loaded.out
 
 # @TEST-EXEC: echo '\nUnload grault' >> loaded.out
-# @TEST-EXEC: zkg -r unload grault >> loaded.out
+# @TEST-EXEC: zkg unload grault >> loaded.out
 
 # @TEST-EXEC: echo '\nInstall foo' >> loaded.out
-# @TEST-EXEC: zkg -r install foo --force >> loaded.out
+# @TEST-EXEC: zkg install foo --force >> loaded.out
 
 # @TEST-EXEC: echo '\nUnload grault' >> loaded.out
-# @TEST-EXEC-FAIL: zkg -r unload grault >> loaded.out
+# @TEST-EXEC-FAIL: zkg unload grault >> loaded.out
 
 # @TEST-EXEC: echo '\nUnload foo' >> loaded.out
-# @TEST-EXEC: zkg -r unload foo >> loaded.out
+# @TEST-EXEC: zkg unload foo >> loaded.out
 
 # @TEST-EXEC: echo '\nLoad foo' >> loaded.out
-# @TEST-EXEC: zkg -r load foo >> loaded.out
+# @TEST-EXEC: zkg load foo >> loaded.out
 
 # @TEST-EXEC: echo '\nRemove grault' >> loaded.out
-# @TEST-EXEC: zkg -r remove grault --force >> loaded.out
+# @TEST-EXEC: zkg remove grault --force >> loaded.out
 
 # @TEST-EXEC: btest-diff loaded.out
 

--- a/testing/tests/runtime-test
+++ b/testing/tests/runtime-test
@@ -1,24 +1,24 @@
 # @TEST-EXEC: bash %INPUT
 
-# @TEST-EXEC: echo '\nInstall grault' > loaded.out
+# @TEST-EXEC: echo 'Install grault' > loaded.out
 # @TEST-EXEC: zkg install grault --force >> loaded.out
 
-# @TEST-EXEC: echo '\nUnload grault' >> loaded.out
+# @TEST-EXEC: echo 'Unload grault' >> loaded.out
 # @TEST-EXEC: zkg unload grault >> loaded.out
 
-# @TEST-EXEC: echo '\nInstall foo' >> loaded.out
+# @TEST-EXEC: echo 'Install foo' >> loaded.out
 # @TEST-EXEC: zkg install foo --force >> loaded.out
 
-# @TEST-EXEC: echo '\nUnload grault' >> loaded.out
+# @TEST-EXEC: echo 'Unload grault' >> loaded.out
 # @TEST-EXEC-FAIL: zkg unload grault >> loaded.out
 
-# @TEST-EXEC: echo '\nUnload foo' >> loaded.out
+# @TEST-EXEC: echo 'Unload foo' >> loaded.out
 # @TEST-EXEC: zkg unload foo >> loaded.out
 
-# @TEST-EXEC: echo '\nLoad foo' >> loaded.out
+# @TEST-EXEC: echo 'Load foo' >> loaded.out
 # @TEST-EXEC: zkg load foo >> loaded.out
 
-# @TEST-EXEC: echo '\nRemove grault' >> loaded.out
+# @TEST-EXEC: echo 'Remove grault' >> loaded.out
 # @TEST-EXEC: zkg remove grault --force >> loaded.out
 
 # @TEST-EXEC: btest-diff loaded.out

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1127,7 +1127,12 @@ class Manager(object):
         for _pkg_name in self.get_pkg_dependencies():
             ipkg = self.find_installed_package(_pkg_name)
             if ipkg and ipkg.status:
+                if ipkg.status.is_loaded == saved_state[_pkg_name]:
+                    continue
                 ipkg.status.is_loaded = saved_state[_pkg_name]
+                self._write_autoloader()
+                self._write_manifest()
+                self._write_plugin_magic(ipkg)
         return
 
     def list_depender_pkgs(self, pkg_path):

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1109,9 +1109,10 @@ class Manager(object):
 
     def write_dependency_state(self):
         try:
-            dep_pickle_path = os.path.join(self.scratch_dir, 'deps.pickle')
-            with open(dep_pickle_path, 'wb') as deps:
-               pickle.dump(self.pkg_dependencies, deps, protocol=pickle.HIGHEST_PROTOCOL)
+            if self.pkg_dependencies:
+                dep_pickle_path = os.path.join(self.scratch_dir, 'deps.pickle')
+                with open(dep_pickle_path, 'wb') as deps:
+                    pickle.dump(self.pkg_dependencies, deps, protocol=pickle.HIGHEST_PROTOCOL)
             return ''
         except Exception as exc:
             return 'Error writing dependencies: {}'.format(str(exc))

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1079,11 +1079,13 @@ class Manager(object):
         LOG.debug('loaded "%s"', pkg_path)
         return ''
 
-    def load_with_dependencies(self, pkg_name):
+    def load_with_dependencies(self, pkg_name, visited):
         """Mark dependent (but previously installed) packages as being "loaded".
 
         Args:
             pkg_name (str): name of the package.
+
+            visited (set(str)): set of packages visited along the recursive loading 
 
         Returns:
             str: empty string if the package is successfully marked as loaded,
@@ -1101,8 +1103,12 @@ class Manager(object):
             return (pkg_name, load_error)
 
         retval = []
+        visited.add(pkg_name)
+
         for pkg in self.find_package_dependencies(pkg_name):
-            retval += self.load_with_dependencies(pkg)
+            if pkg in visited:
+                continue
+            retval += self.load_with_dependencies(pkg, visited)
 
         return retval
 

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1107,23 +1107,14 @@ class Manager(object):
         except Exception as exc:
             return '{}'.format(str(exc))
 
-    def generate_pkg_dependencies(self, new_pkgs):
-        pkg_dependencies = self.load_pkg_dependencies()
-
-        for info, version, _ in new_pkgs:
-            name = name_from_path(info.package.git_url)
-            deps = info.dependencies()
-            pkg_dependencies[name] = deps
-
+    def write_dependency_state(self):
         try:
             dep_pickle_path = os.path.join(self.scratch_dir, 'deps.pickle')
             with open(dep_pickle_path, 'wb') as deps:
-               pickle.dump(pkg_dependencies, deps, protocol=pickle.HIGHEST_PROTOCOL)
+               pickle.dump(self.pkg_dependencies, deps, protocol=pickle.HIGHEST_PROTOCOL)
+            return ''
         except Exception as exc:
-            LOG.debug("Error writing dependencies: ", exc)
-
-        self.pkg_dependencies = pkg_dependencies
-        return pkg_dependencies
+            return 'Error writing dependencies: {}'.format(str(exc))
 
     def load_pkg_dependencies(self):
         try:
@@ -2556,6 +2547,7 @@ class Manager(object):
 
         package.metadata = raw_metadata
         self.installed_pkgs[package.name] = InstalledPackage(package, status)
+        self.pkg_dependencies[package.name] = package.dependencies()
         self._write_manifest()
         LOG.debug('installed "%s"', package)
         return ''

--- a/zkg
+++ b/zkg
@@ -481,8 +481,6 @@ def cmd_install(manager, args, config, configfile):
                         invalid_reason)
             sys.exit(1)
 
-        manager.generate_pkg_dependencies(package_infos + new_pkgs)
-
     if not args.force:
         package_listing = ''
 
@@ -746,8 +744,6 @@ def cmd_bundle(manager, args, config, configfile):
                             invalid_reason)
                 sys.exit(1)
 
-            manager.generate_pkg_dependencies(new_pkgs)
-
         for info, version, suggested in new_pkgs:
             packages_to_bundle.append((info.package.qualified_name(),
                                        info.package.git_url, version, True,
@@ -908,9 +904,6 @@ def cmd_unbundle(manager, args, config, configfile):
             print('Loaded "{}"'.format(name))
 
     print('Unbundling complete.')
-
-    manager.generate_pkg_dependencies([(info, version, git_url) for git_url, version, info in bundle_info])
-
 
 def cmd_remove(manager, args, config, configfile):
     packages_to_remove = []
@@ -1190,8 +1183,6 @@ def cmd_upgrade(manager, args, config, configfile):
             print_error('error: failed to resolve dependencies:',
                         invalid_reason)
             sys.exit(1)
-
-        manager.generate_pkg_dependencies(new_pkgs)
 
     allpkgs = outdated_packages + new_pkgs
 
@@ -2402,6 +2393,9 @@ def main():
 
     args.run_cmd(manager, args, config, configfile)
 
+    has_error = manager.write_dependency_state()
+    if has_error:
+        print('Error writing dependencies: {}'.format(has_error))
 
 if __name__ == '__main__':
     main()

--- a/zkg
+++ b/zkg
@@ -3,6 +3,7 @@
 from __future__ import print_function
 from zeekpkg._util import (
     make_dir,
+    delete_path,
     make_symlink,
     find_program,
     read_zeek_config_line,
@@ -443,7 +444,7 @@ def cmd_install(manager, args, config, configfile):
 
         package_infos.append((package_info, version, False))
 
-    new_pkgs = []
+    orig_pkgs, new_pkgs = package_infos, []
 
     if not args.nodeps:
         to_validate = [(info.package.qualified_name(), version)
@@ -628,6 +629,25 @@ def cmd_install(manager, args, config, configfile):
                 print('Failed loading "{}": {}'.format(name, load_error))
             else:
                 print('Loaded "{}"'.format(name))
+
+    if args.runtime_dep_check:
+        # now load runtime dependencies after all depends and suggested packages
+        # have been installed and loaded. we do not check for 'find_installed_package'
+        # as all worker threads have been merged at this point and all dependencies
+        # are installed
+        saved_state = manager.saveState()
+        load_error = ''
+        for info, ver, _ in orig_pkgs:
+            name = info.package.qualified_name()
+            load_error = manager._load(name)
+
+        if not load_error:
+            _names = [info.package.qualified_name() for info, _, _ in orig_pkgs]
+            dep_listing = manager.get_changed_state(saved_state, _names)
+            if dep_listing:
+                print('The following installed packages were additionally loaded to satisfy' \
+                    ' runtime dependencies')
+                print(dep_listing)
 
     if installs_failed:
         print_error('error: incomplete installation, the follow packages'
@@ -885,10 +905,32 @@ def cmd_remove(manager, args, config, configfile):
 
     for ipkg in packages_to_remove:
         name = ipkg.package.qualified_name()
+
+        dep_packages = []
+        if args.runtime_dep_check:
+            print('The following packages depend on "{}" and removing it will BREAK them.'.format(name))
+            dep_packages = manager.pkg_descendants(name)
+            dep_listing = ''
+            for _name in dep_packages:
+                dep_listing += '  {}\n'.format(_name)
+            print(dep_listing)
+
+            dep_listing = ''
+            for _name in manager.pkg_dependencies:
+                if _name == zeekpkg.package.name_from_path(name):
+                    continue
+                dep_listing += '  {}\n'.format(_name)
+            if dep_listing:
+                print('The following installed packages (or more) will be unloaded as well.')
+            print(dep_listing)
+
+            if not args.force and not confirmation_prompt('Proceed?', default_to_yes=False):
+                continue
+
         modifications = manager.modified_config_files(ipkg)
         backup_files = manager.backup_modified_files(name, modifications)
 
-        if manager.remove(name):
+        if manager.remove(name, dep_packages, args.runtime_dep_check):
             print('Removed "{}"'.format(name))
 
             if backup_files:
@@ -933,7 +975,7 @@ def cmd_purge(manager, args, config, configfile):
         modifications = manager.modified_config_files(ipkg)
         backup_files = manager.backup_modified_files(name, modifications)
 
-        if manager.remove(name):
+        if manager.remove(name, [], args.runtime_dep_check):
             print('Removed "{}"'.format(name))
 
             if backup_files:
@@ -945,6 +987,12 @@ def cmd_purge(manager, args, config, configfile):
         else:
             print('Unknown error removing "{}"'.format(name))
             had_failure = True
+
+    try:
+        _dep_pickle_path = os.path.join(manager.scratch_dir, 'deps.pickle')
+        delete_path(_dep_pickle_path)
+    except Exception as exc:
+        print("Error removing dependencies: ", exc)
 
     if had_failure:
         sys.exit(1)
@@ -1297,10 +1345,23 @@ def cmd_load(manager, args, config, configfile):
             continue
 
         name = ipkg.package.qualified_name()
-        load_error = manager.load(name)
+        if args.runtime_dep_check:
+            saved_state = manager.saveState()
+            load_error = manager._load(name)
+
+            if not load_error:
+                dep_listing = manager.get_changed_state(saved_state, [name])
+                if dep_listing:
+                    print('The following installed packages were additionally loaded to satisfy' \
+                        ' runtime dependencies for "{}".'.format(name))
+                    print(dep_listing)
+        else:
+            load_error = manager.load(name)
 
         if load_error:
             had_failure = True
+            if runtime_dep_check:
+                manager.restoreState(saved_state)
             print('Failed to load "{}": {}'.format(name, load_error))
         else:
             print('Loaded "{}"'.format(name))
@@ -1326,12 +1387,31 @@ def cmd_unload(manager, args, config, configfile):
 
         name = ipkg.package.qualified_name()
 
-        if manager.unload(name):
-            print('Unloaded "{}"'.format(name))
+        if args.runtime_dep_check:
+            saved_state = manager.saveState()
+            if manager._unload(name):
+                dep_listing = manager.get_changed_state(saved_state, [name])
+                if dep_listing:
+                    print('The following installed packages were additionally unloaded to satisfy' \
+                    ' runtime dependencies for "{}".'.format(name))
+                    print(dep_listing)
+                print('Unloaded "{}"'.format(name))
+            else:
+                had_failure = True
+                dep_packages = manager.pkg_descendants(name)
+                dep_listing = ''
+                for _name in dep_packages:
+                    dep_listing += '  {}\n'.format(_name)
+                print('Following packages are dependent on "{}" and are currently in use.'.format(name))
+                print(dep_listing)
+                print('Failed unloading "{}"'.format(name))
+                manager.restoreState(saved_state)
         else:
-            had_failure = True
-            print(
-                'Failed unloading "{}": no such package installed'.format(name))
+            if manager.unload(name):
+                print('Unloaded "{}"'.format(name))
+            else:
+                had_failure = True
+                print('Failed unloading "{}": no such package installed'.format(name))
 
     if had_failure:
         sys.exit(1)
@@ -1806,6 +1886,8 @@ def top_level_parser():
                             ' Use multiple times for more output (e.g. -vvv).')
     top_parser.add_argument('--extra-source', action='append',
                             metavar='NAME=URL', help='Add an extra source.')
+    top_parser.add_argument('--runtime_dep_check', '-r', action = "store_true",
+                            help='Enforce runtime package dependency checks.')
     return top_parser
 
 

--- a/zkg
+++ b/zkg
@@ -299,15 +299,13 @@ def regenerate_dependency_state(manager):
             to_validate, ignore_suggestions=True)
 
     if invalid_reason:
-        print_error('error: failed to resolve dependencies:', invalid_reason)
+        print_error('regenerate_dependency_state: failed to resolve dependencies:', invalid_reason)
         sys.exit(1)
 
     pkg_dependencies = {}
 
     for info, version, _ in new_pkgs:
         name = zeekpkg.package.name_from_path(info.package.git_url)
-        if name not in pkg_dependencies:
-            pkg_dependencies[name] = set(tuple([]))
         deps = info.dependencies()
         pkg_dependencies[name] = deps
 
@@ -755,25 +753,24 @@ def cmd_install(manager, args, config, configfile):
         # as all worker threads have been merged at this point and all dependencies
         # are installed
         for info, ver, _ in sorted(orig_pkgs, key=lambda x: x[0].package.name):
-            saved_state = loaded_package_states(manager)
+            _listing, saved_state = '', loaded_package_states(manager)
             name = info.package.qualified_name()
-            load_error = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
 
-            if not load_error:
+            load_error = manager.load_with_dependencies(zeekpkg.package.name_from_path(name), set())
+            for _name, _error in load_error:
+                if not _error:
+                    _listing += '  {}\n'.format(_name)
+
+            if not _listing:
                 dep_listing = get_changed_state(manager, saved_state, [name])
                 if dep_listing:
                     print('The following installed packages were additionally loaded to satisfy' \
                           ' runtime dependencies')
                     print(dep_listing)
             else:
-                _listing = ''
-                for _name, _error in load_error:
-                    if not _error:
-                        _listing += '  {}\n'.format(_name)
-                if _listing:
-                    print('The following installed packages could NOT be loaded to satisfy' \
-                          ' runtime dependencies for "{}"'.format(name))
-                    print(_listing)
+                print('The following installed packages could NOT be loaded to satisfy' \
+                      ' runtime dependencies for "{}"'.format(name))
+                print(_listing)
                 restoreState(manager, saved_state)
 
     if installs_failed:
@@ -1003,6 +1000,8 @@ def cmd_unbundle(manager, args, config, configfile):
             print('Loaded "{}"'.format(name))
 
     print('Unbundling complete.')
+
+    generate_pkg_dependencies(manager, [(info, version, git_url) for git_url, version, info in bundle_info])
 
 
 def cmd_remove(manager, args, config, configfile):
@@ -1496,9 +1495,9 @@ def cmd_load(manager, args, config, configfile):
         name = ipkg.package.qualified_name()
         if not args.nodeps:
             saved_state = loaded_package_states(manager)
-            load_error = False
+            dep_error_listing, load_error = '', False
 
-            loaded_dep_list = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
+            loaded_dep_list = manager.load_with_dependencies(zeekpkg.package.name_from_path(name), set())
             for _name, _error in loaded_dep_list:
                 if _error:
                     load_error = True
@@ -1515,7 +1514,7 @@ def cmd_load(manager, args, config, configfile):
 
         if load_error:
             had_failure = True
-            if runtime_dep_check:
+            if not args.nodeps:
                 if dep_error_listing:
                     print('The following installed dependencies could not be loaded for "{}".'
                     	.format(name))

--- a/zkg
+++ b/zkg
@@ -342,6 +342,37 @@ def load_pkg_dependencies(manager):
         # this is only in case the pickle file is deleted
         return regenerate_dependency_state(manager)
 
+def loaded_package_states(manager):
+    """Save loaded state for all installed packages.
+
+    Returns:
+        dict: dictionary of load status for installed packages
+    """
+
+    return {name: ipkg.status.is_loaded for name, ipkg in manager.installed_pkgs.items()}
+
+def restoreState(manager, saved_state):
+    """Restores state for installed packages.
+
+    Args:
+        saved_state (dict): dictionary of saved load state for installed
+        packages.
+
+    """
+    try:
+        for _pkg_name in manager.get_pkg_dependencies():
+            ipkg = manager.find_installed_package(_pkg_name)
+            if ipkg and ipkg.status:
+                if ipkg.status.is_loaded == saved_state[_pkg_name]:
+                    continue
+                ipkg.status.is_loaded = saved_state[_pkg_name]
+                manager._write_autoloader()
+                manager._write_manifest()
+                manager._write_plugin_magic(ipkg)
+    except IOError as exc:
+        print(exc)
+        sys.exit(1)
+
 def create_manager(args, config):
     state_dir = config.get('paths', 'state_dir')
     script_dir = config.get('paths', 'script_dir')
@@ -421,8 +452,9 @@ def get_changed_state(manager, saved_state, pkg_lst):
         if _pkg_name in _lst:
             continue
         _ipkg = manager.find_installed_package(_pkg_name)
-        if _ipkg and _ipkg.status.is_loaded != saved_state[_pkg_name]:
-            dep_listing += '  {}\n'.format(_pkg_name)
+        if not _ipkg or _ipkg.status.is_loaded == saved_state[_pkg_name]:
+        	continue
+        dep_listing += '  {}\n'.format(_pkg_name)
     return dep_listing
 
 
@@ -547,7 +579,7 @@ def cmd_install(manager, args, config, configfile):
     if not args.force:
         package_listing = ''
 
-        for info, version, _ in package_infos:
+        for info, version, _ in sorted(package_infos, key=lambda x: x[0].package.name):
             name = info.package.qualified_name()
             package_listing += '  {} ({})\n'.format(name, version)
 
@@ -557,7 +589,7 @@ def cmd_install(manager, args, config, configfile):
         if new_pkgs:
             dependency_listing = ''
 
-            for info, version, suggested in new_pkgs:
+            for info, version, suggested in sorted(new_pkgs, key=lambda x: x[0].package.name):
                 name = info.package.qualified_name()
                 dependency_listing += '  {} ({})'.format(
                     name, version)
@@ -573,7 +605,7 @@ def cmd_install(manager, args, config, configfile):
         allpkgs = package_infos + new_pkgs
         extdep_listing = ''
 
-        for info, version, _ in allpkgs:
+        for info, version, _ in sorted(allpkgs, key=lambda x: x[0].package.name):
             name = info.package.qualified_name()
             extdeps = info.dependencies(field='external_depends')
 
@@ -643,7 +675,7 @@ def cmd_install(manager, args, config, configfile):
 
     installs_failed = []
 
-    for info, version, _ in package_infos:
+    for info, version, _ in sorted(package_infos, key=lambda x: x[0].package.name):
         name = info.package.qualified_name()
         time_accumulator = 0
         tick_count = 0
@@ -722,19 +754,27 @@ def cmd_install(manager, args, config, configfile):
         # have been installed and loaded. we do not check for 'find_installed_package'
         # as all worker threads have been merged at this point and all dependencies
         # are installed
-        saved_state = manager.loaded_package_states()
-        load_error = ''
-        for info, ver, _ in orig_pkgs:
+        for info, ver, _ in sorted(orig_pkgs, key=lambda x: x[0].package.name):
+            saved_state = loaded_package_states(manager)
             name = info.package.qualified_name()
             load_error = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
 
-        if not load_error:
-            _names = [info.package.qualified_name() for info, _, _ in orig_pkgs]
-            dep_listing = get_changed_state(manager, saved_state, _names)
-            if dep_listing:
-                print('The following installed packages were additionally loaded to satisfy' \
-                    ' runtime dependencies')
-                print(dep_listing)
+            if not load_error:
+                dep_listing = get_changed_state(manager, saved_state, [name])
+                if dep_listing:
+                    print('The following installed packages were additionally loaded to satisfy' \
+                          ' runtime dependencies')
+                    print(dep_listing)
+            else:
+                _listing = ''
+                for _name, _error in load_error:
+                    if not _error:
+                        _listing += '  {}\n'.format(_name)
+                if _listing:
+                    print('The following installed packages could NOT be loaded to satisfy' \
+                          ' runtime dependencies for "{}"'.format(name))
+                    print(_listing)
+                restoreState(manager, saved_state)
 
     if installs_failed:
         print_error('error: incomplete installation, the follow packages'
@@ -1022,14 +1062,17 @@ def cmd_remove(manager, args, config, configfile):
         backup_files = manager.backup_modified_files(name, modifications)
 
         if not args.nodeps:
+            saved_state = loaded_package_states(manager)
             # unload all dependers that might break with the removal of this package
             for _name in dep_packages:
                 _ipkg = manager.find_installed_package(_name)
                 if _ipkg and _ipkg.status.is_loaded:
-                    manager.unload_with_unused_dependers(_name)
+                    unload_error = manager.unload_with_unused_dependers(_name)
+                    # had_failure = batched_unload_cleanup(manager, unload_error, saved_state, _name)
 
             # unload all the dependers packages
-            manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name))
+            unload_error = manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name))
+            # had_failure = batched_unload_cleanup(manager, unload_error, saved_state, name)
 
         if manager.remove(name):
             print('Removed "{}"'.format(name))
@@ -1452,8 +1495,8 @@ def cmd_load(manager, args, config, configfile):
 
         name = ipkg.package.qualified_name()
         if not args.nodeps:
-            saved_state = manager.loaded_package_states()
-
+            saved_state = loaded_package_states(manager)
+            load_error = False
 
             loaded_dep_list = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
             for _name, _error in loaded_dep_list:
@@ -1474,9 +1517,10 @@ def cmd_load(manager, args, config, configfile):
             had_failure = True
             if runtime_dep_check:
                 if dep_error_listing:
-                    print('The following installed dependencies could not be loaded.')
+                    print('The following installed dependencies could not be loaded for "{}".'
+                    	.format(name))
                     print(dep_error_listing)
-                manager.restoreState(saved_state)
+                    restoreState(manager, saved_state)
             print('Failed to load "{}": {}'.format(name, load_error))
         else:
             print('Loaded "{}"'.format(name))
@@ -1503,24 +1547,9 @@ def cmd_unload(manager, args, config, configfile):
         name = ipkg.package.qualified_name()
 
         if not args.nodeps:
-            saved_state = manager.loaded_package_states()
-            if manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name)):
-                dep_listing = get_changed_state(manager, saved_state, [name])
-                if dep_listing:
-                    print('The following installed packages were additionally unloaded to satisfy' \
-                    ' runtime dependencies for "{}".'.format(name))
-                    print(dep_listing)
-                print('Unloaded "{}"'.format(name))
-            else:
-                had_failure = True
-                dep_packages = manager.list_depender_pkgs(name)
-                dep_listing = ''
-                for _name in dep_packages:
-                    dep_listing += '  {}\n'.format(_name)
-                print('Following packages are dependent on "{}" and are currently in use.'.format(name))
-                print(dep_listing)
-                print('Failed unloading "{}"'.format(name))
-                manager.restoreState(saved_state)
+            saved_state = loaded_package_states(manager)
+            unload_error = manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name))
+            had_failure = batched_unload_cleanup(manager, unload_error, saved_state, name)
         else:
             if manager.unload(name):
                 print('Unloaded "{}"'.format(name))
@@ -1531,6 +1560,27 @@ def cmd_unload(manager, args, config, configfile):
     if had_failure:
         sys.exit(1)
 
+
+def batched_unload_cleanup(manager, unload_error, saved_state, name):
+    err_listing, had_failure = '', False
+    for _name, _error in unload_error:
+        if _error:
+            err_listing += '  {}: {}\n'.format(_name, _error)
+
+    if not err_listing:
+        dep_listing = get_changed_state(manager, saved_state, [name])
+        if dep_listing:
+            print('The following installed packages were additionally unloaded to satisfy' \
+            ' runtime dependencies for "{}".'.format(name))
+            print(dep_listing)
+        print('Unloaded "{}"'.format(name))
+    else:
+        had_failure = True
+        print('Following packages could not be unloaded.')
+        print(err_listing)
+        print('Failed unloading "{}"'.format(name))
+        restoreState(manager, saved_state)
+    return had_failure
 
 def cmd_pin(manager, args, config, configfile):
     had_failure = False
@@ -2001,8 +2051,6 @@ def top_level_parser():
                             ' Use multiple times for more output (e.g. -vvv).')
     top_parser.add_argument('--extra-source', action='append',
                             metavar='NAME=URL', help='Add an extra source.')
-    top_parser.add_argument('--nodeps', action = "store_true",
-                            help='Skip all runtime package dependency checks.')
     return top_parser
 
 
@@ -2067,11 +2115,11 @@ def argparser():
     sub_parser.add_argument(
         '--skiptests', action='store_true',
         help='Skip running unit tests for packages before installation.')
-    # sub_parser.add_argument(
-    #     '--nodeps', action='store_true',
-    #     help='Skip all dependency resolution/checks.  Note that using this'
-    #     ' option risks putting your installed package collection into a'
-    #     ' broken or unusable state.')
+    sub_parser.add_argument(
+        '--nodeps', action='store_true',
+        help='Skip all dependency resolution/checks.  Note that using this'
+        ' option risks putting your installed package collection into a'
+        ' broken or unusable state.')
     sub_parser.add_argument(
         '--nosuggestions', action='store_true',
         help='Skip automatically installing suggested packages.')
@@ -2116,11 +2164,11 @@ def argparser():
     sub_parser.add_argument(
         '--force', action='store_true',
         help='Skip the confirmation prompt.')
-    # sub_parser.add_argument(
-    #     '--nodeps', action='store_true',
-    #     help='Skip all dependency resolution/checks.  Note that using this'
-    #     ' option risks creating a bundle of packages that is in a'
-    #     ' broken or unusable state.')
+    sub_parser.add_argument(
+        '--nodeps', action='store_true',
+        help='Skip all dependency resolution/checks.  Note that using this'
+        ' option risks creating a bundle of packages that is in a'
+        ' broken or unusable state.')
     sub_parser.add_argument(
         '--nosuggestions', action='store_true',
         help='Skip automatically bundling suggested packages.')
@@ -2167,6 +2215,11 @@ def argparser():
     sub_parser.add_argument(
         '--force', action='store_true',
         help='Skip the confirmation prompt.')
+    sub_parser.add_argument(
+        '--nodeps', action='store_true',
+        help='Skip all dependency resolution/checks.  Note that using this'
+        ' option risks putting your installed package collection into a'
+        ' broken or unusable state.')
 
     # purge
     sub_parser = command_parser.add_parser(
@@ -2228,11 +2281,11 @@ def argparser():
     sub_parser.add_argument(
         '--skiptests', action='store_true',
         help='Skip running unit tests for packages before installation.')
-    # sub_parser.add_argument(
-    #     '--nodeps', action='store_true',
-    #     help='Skip all dependency resolution/checks.  Note that using this'
-    #     ' option risks putting your installed package collection into a'
-    #     ' broken or unusable state.')
+    sub_parser.add_argument(
+        '--nodeps', action='store_true',
+        help='Skip all dependency resolution/checks.  Note that using this'
+        ' option risks putting your installed package collection into a'
+        ' broken or unusable state.')
     sub_parser.add_argument(
         '--nosuggestions', action='store_true',
         help='Skip automatically installing suggested packages.')
@@ -2251,6 +2304,11 @@ def argparser():
     sub_parser.add_argument(
         'package', nargs='+', default=[],
         help='Name(s) of package(s) to load.')
+    sub_parser.add_argument(
+        '--nodeps', action='store_true',
+        help='Skip all dependency resolution/checks.  Note that using this'
+        ' option risks putting your installed package collection into a'
+        ' broken or unusable state.')
 
     # unload
     sub_parser = command_parser.add_parser(
@@ -2265,6 +2323,11 @@ def argparser():
     sub_parser.set_defaults(run_cmd=cmd_unload)
     sub_parser.add_argument(
         'package', nargs='+', default=[], help=pkg_name_help)
+    sub_parser.add_argument(
+        '--nodeps', action='store_true',
+        help='Skip all dependency resolution/checks.  Note that using this'
+        ' option risks putting your installed package collection into a'
+        ' broken or unusable state.')
 
     # pin
     sub_parser = command_parser.add_parser(

--- a/zkg
+++ b/zkg
@@ -3,7 +3,6 @@
 from __future__ import print_function
 from zeekpkg._util import (
     make_dir,
-    delete_path,
     make_symlink,
     find_program,
     read_zeek_config_line,
@@ -25,7 +24,6 @@ import filecmp
 import shutil
 import subprocess
 import json
-import pickle
 
 try:
     from backports import configparser
@@ -286,91 +284,6 @@ def is_git_repo_dirty(git_url):
 
     return repo.is_dirty(untracked_files=True)
 
-def regenerate_dependency_state(manager):
-    """
-    Regenerates package dependencies from installed packages.
-    """
-    new_pkgs = []
-
-    to_validate = [(ipkg.package.qualified_name(), ipkg.status.current_version)
-                       for ipkg in manager.installed_packages()]
-
-    invalid_reason, new_pkgs = manager.validate_dependencies(
-            to_validate, ignore_suggestions=True)
-
-    if invalid_reason:
-        print_error('regenerate_dependency_state: failed to resolve dependencies:', invalid_reason)
-        sys.exit(1)
-
-    pkg_dependencies = {}
-
-    for info, version, _ in new_pkgs:
-        name = zeekpkg.package.name_from_path(info.package.git_url)
-        deps = info.dependencies()
-        pkg_dependencies[name] = deps
-
-    return pkg_dependencies
-
-def generate_pkg_dependencies(manager, new_pkgs):
-    pkg_dependencies = load_pkg_dependencies(manager)
-
-    for info, version, _ in new_pkgs:
-        name = zeekpkg.package.name_from_path(info.package.git_url)
-        deps = info.dependencies()
-        pkg_dependencies[name] = deps
-
-    try:
-        dep_pickle_path = os.path.join(manager.scratch_dir, 'deps.pickle')
-        with open(dep_pickle_path, 'wb') as deps:
-           pickle.dump(pkg_dependencies, deps, protocol=pickle.HIGHEST_PROTOCOL)
-    except Exception as exc:
-        zeekpkg.LOG.debug("Error writing dependencies: ", exc)
-
-    manager.set_pkg_dependencies(pkg_dependencies)
-    return pkg_dependencies
-
-def load_pkg_dependencies(manager):
-    try:
-        dep_pickle_path = os.path.join(manager.scratch_dir, 'deps.pickle')
-        with open(dep_pickle_path, 'rb') as deps:
-            return pickle.load(deps)
-    except Exception as exc:
-        zeekpkg.LOG.debug("Error reading dependencies: ", exc)
-        zeekpkg.LOG.debug("Extracting dependencies")        
-        # this is only in case the pickle file is deleted
-        return regenerate_dependency_state(manager)
-
-def loaded_package_states(manager):
-    """Save loaded state for all installed packages.
-
-    Returns:
-        dict: dictionary of load status for installed packages
-    """
-
-    return {name: ipkg.status.is_loaded for name, ipkg in manager.installed_pkgs.items()}
-
-def restoreState(manager, saved_state):
-    """Restores state for installed packages.
-
-    Args:
-        saved_state (dict): dictionary of saved load state for installed
-        packages.
-
-    """
-    try:
-        for _pkg_name in manager.get_pkg_dependencies():
-            ipkg = manager.find_installed_package(_pkg_name)
-            if ipkg and ipkg.status:
-                if ipkg.status.is_loaded == saved_state[_pkg_name]:
-                    continue
-                ipkg.status.is_loaded = saved_state[_pkg_name]
-                manager._write_autoloader()
-                manager._write_manifest()
-                manager._write_plugin_magic(ipkg)
-    except IOError as exc:
-        print(exc)
-        sys.exit(1)
-
 def create_manager(args, config):
     state_dir = config.get('paths', 'state_dir')
     script_dir = config.get('paths', 'script_dir')
@@ -401,9 +314,6 @@ def create_manager(args, config):
             sys.exit(1)
 
         raise
-
-    pkg_dependencies = load_pkg_dependencies(manager)
-    manager.set_pkg_dependencies(pkg_dependencies)
 
     extra_sources = []
 
@@ -446,7 +356,7 @@ def get_changed_state(manager, saved_state, pkg_lst):
     """
     _lst = [zeekpkg.package.name_from_path(_pkg_path) for _pkg_path in pkg_lst]
     dep_listing = ''
-    for _pkg_name in sorted(manager.get_pkg_dependencies()):
+    for _pkg_name in sorted(manager.pkg_dependencies):
         if _pkg_name in _lst:
             continue
         _ipkg = manager.find_installed_package(_pkg_name)
@@ -571,8 +481,7 @@ def cmd_install(manager, args, config, configfile):
                         invalid_reason)
             sys.exit(1)
 
-        pkg_dependencies = generate_pkg_dependencies(manager, package_infos + new_pkgs)
-        manager.set_pkg_dependencies(pkg_dependencies)
+        manager.generate_pkg_dependencies(package_infos + new_pkgs)
 
     if not args.force:
         package_listing = ''
@@ -753,10 +662,10 @@ def cmd_install(manager, args, config, configfile):
         # as all worker threads have been merged at this point and all dependencies
         # are installed
         for info, ver, _ in sorted(orig_pkgs, key=lambda x: x[0].package.name):
-            _listing, saved_state = '', loaded_package_states(manager)
+            _listing, saved_state = '', manager.loaded_package_states()
             name = info.package.qualified_name()
 
-            load_error = manager.load_with_dependencies(zeekpkg.package.name_from_path(name), set())
+            load_error = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
             for _name, _error in load_error:
                 if not _error:
                     _listing += '  {}\n'.format(_name)
@@ -771,7 +680,7 @@ def cmd_install(manager, args, config, configfile):
                 print('The following installed packages could NOT be loaded to satisfy' \
                       ' runtime dependencies for "{}"'.format(name))
                 print(_listing)
-                restoreState(manager, saved_state)
+                manager.restoreState(saved_state)
 
     if installs_failed:
         print_error('error: incomplete installation, the follow packages'
@@ -837,8 +746,7 @@ def cmd_bundle(manager, args, config, configfile):
                             invalid_reason)
                 sys.exit(1)
 
-            pkg_dependencies = generate_pkg_dependencies(manager, new_pkgs)
-            manager.set_pkg_dependencies(pkg_dependencies)
+            manager.generate_pkg_dependencies(new_pkgs)
 
         for info, version, suggested in new_pkgs:
             packages_to_bundle.append((info.package.qualified_name(),
@@ -1001,7 +909,7 @@ def cmd_unbundle(manager, args, config, configfile):
 
     print('Unbundling complete.')
 
-    generate_pkg_dependencies(manager, [(info, version, git_url) for git_url, version, info in bundle_info])
+    manager.generate_pkg_dependencies([(info, version, git_url) for git_url, version, info in bundle_info])
 
 
 def cmd_remove(manager, args, config, configfile):
@@ -1046,7 +954,7 @@ def cmd_remove(manager, args, config, configfile):
             	print(dep_listing)
 
             dep_listing = ''
-            for _name in sorted(manager.get_pkg_dependencies()):
+            for _name in sorted(manager.pkg_dependencies):
                 if _name == zeekpkg.package.name_from_path(name):
                     continue
                 dep_listing += '  {}\n'.format(_name)
@@ -1061,17 +969,17 @@ def cmd_remove(manager, args, config, configfile):
         backup_files = manager.backup_modified_files(name, modifications)
 
         if not args.nodeps:
-            saved_state = loaded_package_states(manager)
+            saved_state = manager.loaded_package_states()
             # unload all dependers that might break with the removal of this package
             for _name in dep_packages:
                 _ipkg = manager.find_installed_package(_name)
                 if _ipkg and _ipkg.status.is_loaded:
                     unload_error = manager.unload_with_unused_dependers(_name)
-                    # had_failure = batched_unload_cleanup(manager, unload_error, saved_state, _name)
+                    had_failure = batched_unload_cleanup(manager, unload_error, saved_state, _name)
 
             # unload all the dependers packages
             unload_error = manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name))
-            # had_failure = batched_unload_cleanup(manager, unload_error, saved_state, name)
+            had_failure = batched_unload_cleanup(manager, unload_error, saved_state, name)
 
         if manager.remove(name):
             print('Removed "{}"'.format(name))
@@ -1131,11 +1039,9 @@ def cmd_purge(manager, args, config, configfile):
             print('Unknown error removing "{}"'.format(name))
             had_failure = True
 
-    try:
-        _dep_pickle_path = os.path.join(manager.scratch_dir, 'deps.pickle')
-        delete_path(_dep_pickle_path)
-    except Exception as exc:
-        print("Error removing dependencies: ", exc)
+    has_error = manager.purge_dependency_state()
+    if has_error:
+        print('Error removing dependencies: {}'.format(has_error))
 
     if had_failure:
         sys.exit(1)
@@ -1285,8 +1191,7 @@ def cmd_upgrade(manager, args, config, configfile):
                         invalid_reason)
             sys.exit(1)
 
-        pkg_dependencies = generate_pkg_dependencies(manager, new_pkgs)
-        manager.set_pkg_dependencies(pkg_dependencies)
+        manager.generate_pkg_dependencies(new_pkgs)
 
     allpkgs = outdated_packages + new_pkgs
 
@@ -1494,10 +1399,10 @@ def cmd_load(manager, args, config, configfile):
 
         name = ipkg.package.qualified_name()
         if not args.nodeps:
-            saved_state = loaded_package_states(manager)
+            saved_state = manager.loaded_package_states()
             dep_error_listing, load_error = '', False
 
-            loaded_dep_list = manager.load_with_dependencies(zeekpkg.package.name_from_path(name), set())
+            loaded_dep_list = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
             for _name, _error in loaded_dep_list:
                 if _error:
                     load_error = True
@@ -1519,7 +1424,7 @@ def cmd_load(manager, args, config, configfile):
                     print('The following installed dependencies could not be loaded for "{}".'
                     	.format(name))
                     print(dep_error_listing)
-                    restoreState(manager, saved_state)
+                    manager.restoreState(saved_state)
             print('Failed to load "{}": {}'.format(name, load_error))
         else:
             print('Loaded "{}"'.format(name))
@@ -1546,7 +1451,7 @@ def cmd_unload(manager, args, config, configfile):
         name = ipkg.package.qualified_name()
 
         if not args.nodeps:
-            saved_state = loaded_package_states(manager)
+            saved_state = manager.loaded_package_states()
             unload_error = manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name))
             had_failure = batched_unload_cleanup(manager, unload_error, saved_state, name)
         else:
@@ -1578,7 +1483,7 @@ def batched_unload_cleanup(manager, unload_error, saved_state, name):
         print('Following packages could not be unloaded.')
         print(err_listing)
         print('Failed unloading "{}"'.format(name))
-        restoreState(manager, saved_state)
+        manager.restoreState(saved_state)
     return had_failure
 
 def cmd_pin(manager, args, config, configfile):

--- a/zkg
+++ b/zkg
@@ -25,6 +25,7 @@ import filecmp
 import shutil
 import subprocess
 import json
+import pickle
 
 try:
     from backports import configparser
@@ -285,6 +286,62 @@ def is_git_repo_dirty(git_url):
 
     return repo.is_dirty(untracked_files=True)
 
+def regenerate_dependency_state(manager):
+    """
+    Regenerates package dependencies from installed packages.
+    """
+    new_pkgs = []
+
+    to_validate = [(ipkg.package.qualified_name(), ipkg.status.current_version)
+                       for ipkg in manager.installed_packages()]
+
+    invalid_reason, new_pkgs = manager.validate_dependencies(
+            to_validate, ignore_suggestions=True)
+
+    if invalid_reason:
+        print_error('error: failed to resolve dependencies:', invalid_reason)
+        sys.exit(1)
+
+    pkg_dependencies = {}
+
+    for info, version, _ in new_pkgs:
+        name = zeekpkg.package.name_from_path(info.package.git_url)
+        if name not in pkg_dependencies:
+            pkg_dependencies[name] = set(tuple([]))
+        deps = info.dependencies()
+        pkg_dependencies[name] = deps
+
+    return pkg_dependencies
+
+def generate_pkg_dependencies(manager, new_pkgs):
+    pkg_dependencies = load_pkg_dependencies(manager)
+
+    for info, version, _ in new_pkgs:
+        name = zeekpkg.package.name_from_path(info.package.git_url)
+        deps = info.dependencies()
+        pkg_dependencies[name] = deps
+
+    try:
+        dep_pickle_path = os.path.join(manager.scratch_dir, 'deps.pickle')
+        with open(dep_pickle_path, 'wb') as deps:
+           pickle.dump(pkg_dependencies, deps, protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception as exc:
+        zeekpkg.LOG.debug("Error writing dependencies: ", exc)
+
+    manager.set_pkg_dependencies(pkg_dependencies)
+    return pkg_dependencies
+
+def load_pkg_dependencies(manager):
+    try:
+        dep_pickle_path = os.path.join(manager.scratch_dir, 'deps.pickle')
+        with open(dep_pickle_path, 'rb') as deps:
+            return pickle.load(deps)
+    except Exception as exc:
+        zeekpkg.LOG.debug("Error reading dependencies: ", exc)
+        zeekpkg.LOG.debug("Extracting dependencies")        
+        # this is only in case the pickle file is deleted
+        return regenerate_dependency_state(manager)
+
 def create_manager(args, config):
     state_dir = config.get('paths', 'state_dir')
     script_dir = config.get('paths', 'script_dir')
@@ -316,6 +373,9 @@ def create_manager(args, config):
 
         raise
 
+    pkg_dependencies = load_pkg_dependencies(manager)
+    manager.set_pkg_dependencies(pkg_dependencies)
+
     extra_sources = []
 
     for key_value in args.extra_source or []:
@@ -341,6 +401,7 @@ def create_manager(args, config):
 
     return manager
 
+
 def get_changed_state(manager, saved_state, pkg_lst):
     """Returns the list of packages that have changed loaded state.
 
@@ -356,13 +417,14 @@ def get_changed_state(manager, saved_state, pkg_lst):
     """
     _lst = [zeekpkg.package.name_from_path(_pkg_path) for _pkg_path in pkg_lst]
     dep_listing = ''
-    for _pkg_name in manager.pkg_dependencies:
+    for _pkg_name in sorted(manager.get_pkg_dependencies()):
         if _pkg_name in _lst:
             continue
         _ipkg = manager.find_installed_package(_pkg_name)
         if _ipkg and _ipkg.status.is_loaded != saved_state[_pkg_name]:
             dep_listing += '  {}\n'.format(_pkg_name)
     return dep_listing
+
 
 class InstallWorker(threading.Thread):
 
@@ -474,17 +536,13 @@ def cmd_install(manager, args, config, configfile):
         invalid_reason, new_pkgs = manager.validate_dependencies(
             to_validate, ignore_suggestions=args.nosuggestions)
 
-        for info, version, suggested in new_pkgs:
-        	deps = info.dependencies()
-        	name_ = info.package.git_url
-        	name = info.package.qualified_name()
-        	_name = zeekpkg.package.name_from_path(name)
-        	print(_name, name_, version, deps)
-
         if invalid_reason:
             print_error('error: failed to resolve dependencies:',
                         invalid_reason)
             sys.exit(1)
+
+        pkg_dependencies = generate_pkg_dependencies(manager, package_infos + new_pkgs)
+        manager.set_pkg_dependencies(pkg_dependencies)
 
     if not args.force:
         package_listing = ''
@@ -668,7 +726,7 @@ def cmd_install(manager, args, config, configfile):
         load_error = ''
         for info, ver, _ in orig_pkgs:
             name = info.package.qualified_name()
-            load_error = manager.load_with_dependencies(name)
+            load_error = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
 
         if not load_error:
             _names = [info.package.qualified_name() for info, _, _ in orig_pkgs]
@@ -741,6 +799,9 @@ def cmd_bundle(manager, args, config, configfile):
                 print_error('error: failed to resolve dependencies:',
                             invalid_reason)
                 sys.exit(1)
+
+            pkg_dependencies = generate_pkg_dependencies(manager, new_pkgs)
+            manager.set_pkg_dependencies(pkg_dependencies)
 
         for info, version, suggested in new_pkgs:
             packages_to_bundle.append((info.package.qualified_name(),
@@ -937,7 +998,7 @@ def cmd_remove(manager, args, config, configfile):
 
         dep_packages = []
         if not args.nodeps:
-            dep_packages = manager.list_depender_pkgs(name)
+            dep_packages = sorted(manager.list_depender_pkgs(name))
             if dep_packages:
             	print('The following packages depend on "{}" and removing it will BREAK them.'.format(name))
             	dep_listing = ''
@@ -946,7 +1007,7 @@ def cmd_remove(manager, args, config, configfile):
             	print(dep_listing)
 
             dep_listing = ''
-            for _name in manager.pkg_dependencies:
+            for _name in sorted(manager.get_pkg_dependencies()):
                 if _name == zeekpkg.package.name_from_path(name):
                     continue
                 dep_listing += '  {}\n'.format(_name)
@@ -968,7 +1029,7 @@ def cmd_remove(manager, args, config, configfile):
                     manager.unload_with_unused_dependers(_name)
 
             # unload all the dependers packages
-            manager.unload_with_unused_dependers(name)
+            manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name))
 
         if manager.remove(name):
             print('Removed "{}"'.format(name))
@@ -1182,6 +1243,9 @@ def cmd_upgrade(manager, args, config, configfile):
                         invalid_reason)
             sys.exit(1)
 
+        pkg_dependencies = generate_pkg_dependencies(manager, new_pkgs)
+        manager.set_pkg_dependencies(pkg_dependencies)
+
     allpkgs = outdated_packages + new_pkgs
 
     if not args.force:
@@ -1390,7 +1454,8 @@ def cmd_load(manager, args, config, configfile):
         if not args.nodeps:
             saved_state = manager.loaded_package_states()
 
-            loaded_dep_list = manager.load_with_dependencies(name)
+
+            loaded_dep_list = manager.load_with_dependencies(zeekpkg.package.name_from_path(name))
             for _name, _error in loaded_dep_list:
                 if _error:
                     load_error = True
@@ -1439,7 +1504,7 @@ def cmd_unload(manager, args, config, configfile):
 
         if not args.nodeps:
             saved_state = manager.loaded_package_states()
-            if manager.unload_with_unused_dependers(name):
+            if manager.unload_with_unused_dependers(zeekpkg.package.name_from_path(name)):
                 dep_listing = get_changed_state(manager, saved_state, [name])
                 if dep_listing:
                     print('The following installed packages were additionally unloaded to satisfy' \

--- a/zkg
+++ b/zkg
@@ -341,6 +341,28 @@ def create_manager(args, config):
 
     return manager
 
+def get_changed_state(manager, saved_state, pkg_lst):
+    """Returns the list of packages that have changed loaded state.
+
+    Args:
+        saved_state (dict): dictionary of saved load state for installed
+        packages.
+
+        pkg_lst (list): list of package names to be skipped
+
+    Returns:
+        dep_listing (str): string installed packages that have changed state
+    
+    """
+    _lst = [zeekpkg.package.name_from_path(_pkg_path) for _pkg_path in pkg_lst]
+    dep_listing = ''
+    for _pkg_name in manager.pkg_dependencies:
+        if _pkg_name in _lst:
+            continue
+        _ipkg = manager.find_installed_package(_pkg_name)
+        if _ipkg and _ipkg.status.is_loaded != saved_state[_pkg_name]:
+            dep_listing += '  {}\n'.format(_pkg_name)
+    return dep_listing
 
 class InstallWorker(threading.Thread):
 
@@ -451,6 +473,13 @@ def cmd_install(manager, args, config, configfile):
                        for info, version, _ in package_infos]
         invalid_reason, new_pkgs = manager.validate_dependencies(
             to_validate, ignore_suggestions=args.nosuggestions)
+
+        for info, version, suggested in new_pkgs:
+        	deps = info.dependencies()
+        	name_ = info.package.git_url
+        	name = info.package.qualified_name()
+        	_name = zeekpkg.package.name_from_path(name)
+        	print(_name, name_, version, deps)
 
         if invalid_reason:
             print_error('error: failed to resolve dependencies:',
@@ -630,20 +659,20 @@ def cmd_install(manager, args, config, configfile):
             else:
                 print('Loaded "{}"'.format(name))
 
-    if args.runtime_dep_check:
+    if not args.nodeps:
         # now load runtime dependencies after all depends and suggested packages
         # have been installed and loaded. we do not check for 'find_installed_package'
         # as all worker threads have been merged at this point and all dependencies
         # are installed
-        saved_state = manager.saveState()
+        saved_state = manager.loaded_package_states()
         load_error = ''
         for info, ver, _ in orig_pkgs:
             name = info.package.qualified_name()
-            load_error = manager._load(name)
+            load_error = manager.load_with_dependencies(name)
 
         if not load_error:
             _names = [info.package.qualified_name() for info, _, _ in orig_pkgs]
-            dep_listing = manager.get_changed_state(saved_state, _names)
+            dep_listing = get_changed_state(manager, saved_state, _names)
             if dep_listing:
                 print('The following installed packages were additionally loaded to satisfy' \
                     ' runtime dependencies')
@@ -907,13 +936,14 @@ def cmd_remove(manager, args, config, configfile):
         name = ipkg.package.qualified_name()
 
         dep_packages = []
-        if args.runtime_dep_check:
-            print('The following packages depend on "{}" and removing it will BREAK them.'.format(name))
-            dep_packages = manager.pkg_descendants(name)
-            dep_listing = ''
-            for _name in dep_packages:
-                dep_listing += '  {}\n'.format(_name)
-            print(dep_listing)
+        if not args.nodeps:
+            dep_packages = manager.list_depender_pkgs(name)
+            if dep_packages:
+            	print('The following packages depend on "{}" and removing it will BREAK them.'.format(name))
+            	dep_listing = ''
+            	for _name in dep_packages:
+            		dep_listing += '  {}\n'.format(_name)
+            	print(dep_listing)
 
             dep_listing = ''
             for _name in manager.pkg_dependencies:
@@ -922,7 +952,7 @@ def cmd_remove(manager, args, config, configfile):
                 dep_listing += '  {}\n'.format(_name)
             if dep_listing:
                 print('The following installed packages (or more) will be unloaded as well.')
-            print(dep_listing)
+                print(dep_listing)
 
             if not args.force and not confirmation_prompt('Proceed?', default_to_yes=False):
                 continue
@@ -930,7 +960,17 @@ def cmd_remove(manager, args, config, configfile):
         modifications = manager.modified_config_files(ipkg)
         backup_files = manager.backup_modified_files(name, modifications)
 
-        if manager.remove(name, dep_packages, args.runtime_dep_check):
+        if not args.nodeps:
+            # unload all dependers that might break with the removal of this package
+            for _name in dep_packages:
+                _ipkg = manager.find_installed_package(_name)
+                if _ipkg and _ipkg.status.is_loaded:
+                    manager.unload_with_unused_dependers(_name)
+
+            # unload all the dependers packages
+            manager.unload_with_unused_dependers(name)
+
+        if manager.remove(name):
             print('Removed "{}"'.format(name))
 
             if backup_files:
@@ -975,7 +1015,7 @@ def cmd_purge(manager, args, config, configfile):
         modifications = manager.modified_config_files(ipkg)
         backup_files = manager.backup_modified_files(name, modifications)
 
-        if manager.remove(name, [], args.runtime_dep_check):
+        if manager.remove(name):
             print('Removed "{}"'.format(name))
 
             if backup_files:
@@ -1331,6 +1371,8 @@ def cmd_upgrade(manager, args, config, configfile):
 
 def cmd_load(manager, args, config, configfile):
     had_failure = False
+    load_error = False
+    dep_error_listing = ''
 
     for name in args.package:
         ipkg = manager.find_installed_package(name)
@@ -1345,12 +1387,17 @@ def cmd_load(manager, args, config, configfile):
             continue
 
         name = ipkg.package.qualified_name()
-        if args.runtime_dep_check:
-            saved_state = manager.saveState()
-            load_error = manager._load(name)
+        if not args.nodeps:
+            saved_state = manager.loaded_package_states()
+
+            loaded_dep_list = manager.load_with_dependencies(name)
+            for _name, _error in loaded_dep_list:
+                if _error:
+                    load_error = True
+                    dep_error_listing += '  {}: {}\n'.format(_name, _error)
 
             if not load_error:
-                dep_listing = manager.get_changed_state(saved_state, [name])
+                dep_listing = get_changed_state(manager, saved_state, [name])
                 if dep_listing:
                     print('The following installed packages were additionally loaded to satisfy' \
                         ' runtime dependencies for "{}".'.format(name))
@@ -1361,6 +1408,9 @@ def cmd_load(manager, args, config, configfile):
         if load_error:
             had_failure = True
             if runtime_dep_check:
+                if dep_error_listing:
+                    print('The following installed dependencies could not be loaded.')
+                    print(dep_error_listing)
                 manager.restoreState(saved_state)
             print('Failed to load "{}": {}'.format(name, load_error))
         else:
@@ -1387,10 +1437,10 @@ def cmd_unload(manager, args, config, configfile):
 
         name = ipkg.package.qualified_name()
 
-        if args.runtime_dep_check:
-            saved_state = manager.saveState()
-            if manager._unload(name):
-                dep_listing = manager.get_changed_state(saved_state, [name])
+        if not args.nodeps:
+            saved_state = manager.loaded_package_states()
+            if manager.unload_with_unused_dependers(name):
+                dep_listing = get_changed_state(manager, saved_state, [name])
                 if dep_listing:
                     print('The following installed packages were additionally unloaded to satisfy' \
                     ' runtime dependencies for "{}".'.format(name))
@@ -1398,7 +1448,7 @@ def cmd_unload(manager, args, config, configfile):
                 print('Unloaded "{}"'.format(name))
             else:
                 had_failure = True
-                dep_packages = manager.pkg_descendants(name)
+                dep_packages = manager.list_depender_pkgs(name)
                 dep_listing = ''
                 for _name in dep_packages:
                     dep_listing += '  {}\n'.format(_name)
@@ -1886,8 +1936,8 @@ def top_level_parser():
                             ' Use multiple times for more output (e.g. -vvv).')
     top_parser.add_argument('--extra-source', action='append',
                             metavar='NAME=URL', help='Add an extra source.')
-    top_parser.add_argument('--runtime_dep_check', '-r', action = "store_true",
-                            help='Enforce runtime package dependency checks.')
+    top_parser.add_argument('--nodeps', action = "store_true",
+                            help='Skip all runtime package dependency checks.')
     return top_parser
 
 
@@ -1952,11 +2002,11 @@ def argparser():
     sub_parser.add_argument(
         '--skiptests', action='store_true',
         help='Skip running unit tests for packages before installation.')
-    sub_parser.add_argument(
-        '--nodeps', action='store_true',
-        help='Skip all dependency resolution/checks.  Note that using this'
-        ' option risks putting your installed package collection into a'
-        ' broken or unusable state.')
+    # sub_parser.add_argument(
+    #     '--nodeps', action='store_true',
+    #     help='Skip all dependency resolution/checks.  Note that using this'
+    #     ' option risks putting your installed package collection into a'
+    #     ' broken or unusable state.')
     sub_parser.add_argument(
         '--nosuggestions', action='store_true',
         help='Skip automatically installing suggested packages.')
@@ -2001,11 +2051,11 @@ def argparser():
     sub_parser.add_argument(
         '--force', action='store_true',
         help='Skip the confirmation prompt.')
-    sub_parser.add_argument(
-        '--nodeps', action='store_true',
-        help='Skip all dependency resolution/checks.  Note that using this'
-        ' option risks creating a bundle of packages that is in a'
-        ' broken or unusable state.')
+    # sub_parser.add_argument(
+    #     '--nodeps', action='store_true',
+    #     help='Skip all dependency resolution/checks.  Note that using this'
+    #     ' option risks creating a bundle of packages that is in a'
+    #     ' broken or unusable state.')
     sub_parser.add_argument(
         '--nosuggestions', action='store_true',
         help='Skip automatically bundling suggested packages.')
@@ -2113,11 +2163,11 @@ def argparser():
     sub_parser.add_argument(
         '--skiptests', action='store_true',
         help='Skip running unit tests for packages before installation.')
-    sub_parser.add_argument(
-        '--nodeps', action='store_true',
-        help='Skip all dependency resolution/checks.  Note that using this'
-        ' option risks putting your installed package collection into a'
-        ' broken or unusable state.')
+    # sub_parser.add_argument(
+    #     '--nodeps', action='store_true',
+    #     help='Skip all dependency resolution/checks.  Note that using this'
+    #     ' option risks putting your installed package collection into a'
+    #     ' broken or unusable state.')
     sub_parser.add_argument(
         '--nosuggestions', action='store_true',
         help='Skip automatically installing suggested packages.')


### PR DESCRIPTION
- Add support for runtime dependency checks for install, remove, load and unload operations.
- Add a top-level commandline option for the same.
