### PR TITLE
Add `package_base` as a pre-defined configuration key for value interpolation

### DIFF
--- a/doc/package.rst
+++ b/doc/package.rst
@@ -506,6 +506,11 @@ Besides the `bro_dist`/`zeek_dist` config keys, any key inside the
 <zkg-config-file>` that matches the key of an entry in the package's
 `user_vars field`_ will be interpolated.
 
+A further pre-defined config key is `package_base`, which points to
+the top-level directory where :program:`zkg` stores all installed
+packages. This can be used to gain access to the content of another
+package that was installed as a dependency.
+
 Internally, the value substitution and metadata parsing is handled by Python's
 `configparser interpolation`_.  See its documentation if you're interested in
 the details of how the interpolation works.

--- a/testing/baselines/tests.package_base/state.logs.foo-build.log
+++ b/testing/baselines/tests.package_base/state.logs.foo-build.log
@@ -1,0 +1,3 @@
+=== STDERR ===
+=== STDOUT ===
+foo

--- a/testing/tests/package_base
+++ b/testing/tests/package_base
@@ -1,0 +1,8 @@
+# @TEST-EXEC: bash %INPUT
+
+# @TEST-EXEC: zkg install foo
+# @TEST-EXEC: btest-diff state/logs/foo-build.log
+
+cd packages/foo
+echo 'build_command = cd "%(package_base)s" && ls ' >> zkg.meta
+git commit -am 'new stuff'

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -2215,6 +2215,7 @@ class Manager(object):
         substitutions = {
             'bro_dist': self.zeek_dist,
             'zeek_dist': self.zeek_dist,
+            'package_base': self.package_clonedir,
         }
         substitutions.update(self.user_vars)
 


### PR DESCRIPTION
This enables a package to gain access to files from another package in
a well-defined manner. For example, if package `foo` wants to access
file `xyz.cfg` from package "bar", it can now declate `bar` as a
dependency and then use `%(package_base)s/bar/xyz.cfg` from its
`build_command`.

