### PR TITLE
When running tests, use any already installed dependencies rather than rebuilding them.

### DIFF
--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -2097,7 +2097,7 @@ class Manager(object):
         make_dir(stage_plugin_dir)
 
         request = [(package.qualified_name(), version)]
-        invalid_deps, new_pkgs = self.validate_dependencies(request, True)
+        invalid_deps, new_pkgs = self.validate_dependencies(request, False)
 
         if invalid_deps:
             return (invalid_deps, False, test_dir)


### PR DESCRIPTION
Closes #70.

@jsiwek if you're fine with this change and merge it, please also push another release out to pypi.