### PR TITLE
Don't fetch version tags after a git clone of a shallow repo

### DIFF
--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -106,7 +106,13 @@ def git_clone(git_url, dst_path, shallow=False):
     # local git repo that has submodules ?
     rval.git.remote('set-url', 'origin', git_url)
 
-    rval.git.fetch('--no-recurse-submodules', tags=True)
+    # Fetch version tags only if we're not dealing with a shallow
+    # clone, where we only have the most recent commit anyway. This
+    # avoids additional trouble with older git versions, e.g. git
+    # 1.8.3 on Centos 7.
+    if not shallow:
+        rval.git.fetch('--no-recurse-submodules', tags=True)
+
     return rval
 
 


### PR DESCRIPTION
This is an attempt to fix the problem that Jan reported [on zeek-public](https://lists.zeek.org/archives/list/zeek@lists.zeek.org/thread/BMANO5QA67RCMJ5IXMQ7WCOVPYGMR6YF/) when unbundling a bundle with git 1.8.3 on Centos 7. I can confirm that zkg won't unbundle in that setting:

```
2020-10-26 19:31:47 INFO     getting info on "/root/.zkg/scratch/bundle/hassh": invalid git repo path: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch --tags --no-recurse-submodules
  stderr: 'fatal: attempt to fetch/clone from a shallow repository
fatal: Could not read from remote repository.
```

This happens in `git_clone()`, where we have protection against cloning when git doesn't support it, but the subsequent fetch still complains. I'm simply avoiding that fetch in the shallow case. It fixes the problem, and the installed packages still report their version correctly. But I'm not completely sure this is correct — is that fetch mainly there to pull in all version tags? If so, skipping should be safe for shallow clones, no?