### PR TITLE
Remove superfluous "fetch" during git cloning

### DIFF
--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -105,8 +105,6 @@ def git_clone(git_url, dst_path, shallow=False):
     # unintended inheritence of "origin" seems to only happen when cloning a
     # local git repo that has submodules ?
     rval.git.remote('set-url', 'origin', git_url)
-
-    rval.git.fetch('--no-recurse-submodules', tags=True)
     return rval
 
 


### PR DESCRIPTION
Fetching tags used to be necessary for shallow clones, but that now
happens implicitly since changing to use `git clone --no-single-branch`
(which is also needed for zkg's branch-based version tracking).

A secondary `git fetch` after doing a shallow clone also has negative
effect of causing errors on older git versions (e.g. v1.8.3.1, currently
found in CentOS 7) since they prohibit fetching from a shallow clone.

Alternative to #77 for fixing [this reported issue](https://lists.zeek.org/archives/list/zeek@lists.zeek.org/thread/BMANO5QA67RCMJ5IXMQ7WCOVPYGMR6YF/).