### PR TITLE
Enforce dependency requirements of already-installed packages

### DIFF
--- a/testing/baselines/tests.installed-dependency-conflict/conflict.out
+++ b/testing/baselines/tests.installed-dependency-conflict/conflict.out
@@ -1,0 +1,1 @@
+error: failed to resolve dependencies: unsatisfiable dependency: "one/alice/bar" (1.0.0) is installed, but "one/alice/foo" requires =2.0.0

--- a/testing/baselines/tests.installed-dependency-conflict/installed-final.out
+++ b/testing/baselines/tests.installed-dependency-conflict/installed-final.out
@@ -1,0 +1,2 @@
+one/alice/bar (installed: 1.0.0)
+one/alice/foo (installed: 1.0.0)

--- a/testing/baselines/tests.installed-dependency-conflict/installed-initial.out
+++ b/testing/baselines/tests.installed-dependency-conflict/installed-initial.out
@@ -1,0 +1,2 @@
+one/alice/bar (installed: 1.0.0)
+one/alice/foo (installed: 1.0.0)

--- a/testing/tests/installed-dependency-conflict
+++ b/testing/tests/installed-dependency-conflict
@@ -1,0 +1,25 @@
+
+# @TEST-EXEC: bash %INPUT
+
+# @TEST-EXEC: zkg install --version 1.0.0 foo
+# @TEST-EXEC: zkg list installed > installed-initial.out
+
+# @TEST-EXEC-FAIL: zkg install --version 2.0.0 foo >conflict.out 2>&1
+# @TEST-EXEC: zkg list installed > installed-final.out
+
+# @TEST-EXEC: btest-diff installed-initial.out
+# @TEST-EXEC: btest-diff conflict.out
+# @TEST-EXEC: btest-diff installed-final.out
+
+cd packages/foo
+echo 'depends = bar =1.0.0' >> zkg.meta
+git commit -am 'depend on bar 1.0.0'
+git tag -a 1.0.0 -m 1.0.0
+git checkout HEAD~1
+echo 'depends = bar =2.0.0' >> zkg.meta
+git commit -am 'depend on bar 2.0.0'
+git tag -a 2.0.0 -m 2.0.0
+
+cd ../bar
+git tag -a 1.0.0 -m 1.0.0
+git tag -a 2.0.0 -m 2.0.0

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1844,14 +1844,6 @@ class Manager(object):
                 track_method, required_version = node.installed_version
 
                 for depender_name, version_spec in node.dependers.items():
-                    if ( depender_name in graph and
-                         graph[depender_name].installed_version ):
-                        # Both nodes already installed, so assume compatible.
-                        # They're maybe not actually if the user installed via
-                        # --nodeps, but if that's their desired state, it's
-                        # better not to complain about it now.
-                        continue
-
                     if track_method == TRACKING_METHOD_BRANCH:
                         if version_spec == '*':
                             continue


### PR DESCRIPTION
Treat as an error the installing a package that would break dependency
requirements of an already-installed package.

Fixes GH-82

Essentially reverts 19ba89fa, in which it seems like I made a change to make it easier in a case where one decides to go the `--nodeps` route to circumvent dependency requirements, but may not have been wise in retrospect.  Once someone goes `--nodeps`, think they can expect to either need to keep using it to circumvent dependency analysis or else take actions that correct their package installations.
