### PR TITLE
Fix branch-based dependency analysis for packages with no tags 

### DIFF
--- a/testing/baselines/tests.branch-based-dependency/installed.out
+++ b/testing/baselines/tests.branch-based-dependency/installed.out
@@ -1,0 +1,2 @@
+one/alice/bar (installed: release/1.0)
+one/alice/foo (installed: release/1.0)

--- a/testing/baselines/tests.unsatisfied-version-tag-dependency/fail.out
+++ b/testing/baselines/tests.unsatisfied-version-tag-dependency/fail.out
@@ -1,0 +1,3 @@
+error: failed to resolve dependencies: "one/alice/bar" has no version satisfying dependencies:
+	"one/alice/foo" requires: "=1.0.0"
+

--- a/testing/tests/branch-based-dependency
+++ b/testing/tests/branch-based-dependency
@@ -1,0 +1,14 @@
+
+# @TEST-EXEC: bash %INPUT
+
+# @TEST-EXEC: zkg install --version release/1.0 foo
+# @TEST-EXEC: zkg list installed > installed.out
+# @TEST-EXEC: btest-diff installed.out
+
+cd packages/foo
+git checkout -b release/1.0
+echo 'depends = bar branch=release/1.0' >> zkg.meta
+git commit -am 'depend on bar release/1.0'
+
+cd ../bar
+git checkout -b release/1.0

--- a/testing/tests/unsatisfied-version-tag-dependency
+++ b/testing/tests/unsatisfied-version-tag-dependency
@@ -1,0 +1,9 @@
+
+# @TEST-EXEC: bash %INPUT
+
+# @TEST-EXEC-FAIL: zkg install foo >fail.out 2>&1
+# @TEST-EXEC: btest-diff fail.out
+
+cd packages/foo
+echo 'depends = bar =1.0.0' >> zkg.meta
+git commit -am 'depend on bar 1.0.0'

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1917,10 +1917,10 @@ class Manager(object):
                         node.name)
 
                     for depender_name, version_spec in node.dependers.items():
-                        rval += str.format('\t{} needs {}\n',
+                        rval += str.format('\t"{}" requires: "{}"\n',
                                            depender_name, version_spec)
 
-                    return (rval, new_pkgs)
+                    return rval
 
                 for _, version_spec in node.dependers.items():
                     if version_spec.startswith('branch='):

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1907,93 +1907,76 @@ class Manager(object):
                                     new_pkgs)
             else:
                 # Choose best version that satisfies constraints
-                if not node.info.versions:
-                    best_version = 'master'
+                best_version = None
+                need_branch = False
+                need_version = False
+
+                def no_best_version_string(node):
+                    rval = str.format(
+                        '"{}" has no version satisfying dependencies:\n',
+                        node.name)
+
+                    for depender_name, version_spec in node.dependers.items():
+                        rval += str.format('\t{} needs {}\n',
+                                           depender_name, version_spec)
+
+                    return (rval, new_pkgs)
+
+                for _, version_spec in node.dependers.items():
+                    if version_spec.startswith('branch='):
+                        need_branch = True
+                    elif version_spec != '*':
+                        need_version = True
+
+                if need_branch and need_version:
+                    return (no_best_version_string(node), new_pkgs)
+
+                if need_branch:
+                    branch_name = None
 
                     for depender_name, version_spec in node.dependers.items():
                         if version_spec == '*':
                             continue
 
-                        if version_spec.startswith('branch='):
-                            version_spec = version_spec[len('branch='):]
-
-                        if version_spec == best_version:
+                        if not branch_name:
+                            branch_name = version_spec[len('branch='):]
                             continue
 
-                        return (str.format(
-                            'unsatisfiable dependency "{}": "{}" requires {}',
-                            node.name, depender_name, version_spec), new_pkgs)
-                else:
-                    best_version = None
-                    need_branch = False
-                    need_version = False
+                        if branch_name != version_spec[len('branch='):]:
+                            return (no_best_version_string(), new_pkgs)
 
-                    def no_best_version_string(node):
-                        rval = str.format(
-                            '"{}" has no version satisfying dependencies:\n',
-                            node.name)
+                    if branch_name:
+                        best_version = branch_name
+                    else:
+                        best_version = 'master'
+                elif need_version:
+                    for version in node.info.versions[::-1]:
+                        normal_version = _normalize_version_tag(version)
+                        req_semver = semver.Version.coerce(normal_version)
 
-                        for depender_name, version_spec in node.dependers.items():
-                            rval += str.format('\t{} needs {}\n',
-                                               depender_name, version_spec)
-
-                        return (rval, new_pkgs)
-
-                    for _, version_spec in node.dependers.items():
-                        if version_spec.startswith('branch='):
-                            need_branch = True
-                        elif version_spec != '*':
-                            need_version = True
-
-                    if need_branch and need_version:
-                        return (no_best_version_string(node), new_pkgs)
-
-                    if need_branch:
-                        branch_name = None
+                        satisfied = True
 
                         for depender_name, version_spec in node.dependers.items():
-                            if version_spec == '*':
-                                continue
+                            try:
+                                semver_spec = semver.Spec(version_spec)
+                            except ValueError:
+                                return (str.format(
+                                    'package "{}" has invalid semver spec: {}',
+                                    depender_name, version_spec), new_pkgs)
 
-                            if not branch_name:
-                                branch_name = version_spec[len('branch='):]
-                                continue
-
-                            if branch_name != version_spec[len('branch='):]:
-                                return (no_best_version_string(), new_pkgs)
-
-                        if branch_name:
-                            best_version = branch_name
-                        else:
-                            best_version = 'master'
-                    elif need_version:
-                        for version in node.info.versions[::-1]:
-                            normal_version = _normalize_version_tag(version)
-                            req_semver = semver.Version.coerce(normal_version)
-
-                            satisfied = True
-
-                            for depender_name, version_spec in node.dependers.items():
-                                try:
-                                    semver_spec = semver.Spec(version_spec)
-                                except ValueError:
-                                    return (str.format(
-                                        'package "{}" has invalid semver spec: {}',
-                                        depender_name, version_spec), new_pkgs)
-
-                                if req_semver not in semver_spec:
-                                    satisfied = False
-                                    break
-
-                            if satisfied:
-                                best_version = version
+                            if req_semver not in semver_spec:
+                                satisfied = False
                                 break
 
-                        if not best_version:
-                            return (no_best_version_string(node), new_pkgs)
-                    else:
-                        # Must have been all '*' wildcards
-                        best_version = node.info.best_version()
+                        if satisfied:
+                            best_version = version
+                            break
+
+                    if not best_version:
+                        return (no_best_version_string(node), new_pkgs)
+                else:
+                    # Must have been all '*' wildcards or no dependers
+                    best_version = node.info.best_version()
 
                 new_pkgs.append((node.info, best_version, node.is_suggestion))
 


### PR DESCRIPTION
Branch-based dependency analysis was incorrectly skipped for packages
that had no release version tags.

Fixes #83