### PR TITLE
Detect default branch name of packages automatically

### DIFF
--- a/doc/package.rst
+++ b/doc/package.rst
@@ -755,11 +755,11 @@ remote repository:
 
 Alternatively, if you expect to have a simple development process for
 your package, you may choose to not create any version tags and just
-always make commits directly to your package's *master* branch.  Users
-will receive package updates differently depending on whether you decide
-to use release version tags or not.  See the :ref:`package upgrade
-process <package-upgrade-process>` documentation for more details on
-the differences.
+always make commits directly to your package's default branch (typically named
+*main* or *master*).  Users will receive package updates differently depending
+on whether you decide to use release version tags or not.  See the
+:ref:`package upgrade process <package-upgrade-process>` documentation for more
+details on the differences.
 
 .. _package-upgrade-process:
 
@@ -773,7 +773,7 @@ a package.
 The default installation behavior of :program:`zkg` is to look for
 the latest release version tag and install that.  If there are no such
 version tags, it will fall back to installing the latest commit of the
-package's *master* branch
+package's default branch (typically named *main* or *master*)
 
 Upon installing a package via a :ref:`git version tag
 <package-versioning>`, the :ref:`upgrade command <upgrade-command>` will

--- a/testing/baselines/tests.dependency-management/out
+++ b/testing/baselines/tests.dependency-management/out
@@ -15,7 +15,7 @@ Installing "one/alice/baz"
 Installed "one/alice/baz" (1.0.0)
 Loaded "one/alice/baz"
 Installing "one/alice/foo"
-Installed "one/alice/foo" (master)
+Installed "one/alice/foo" (main)
 Loaded "one/alice/foo"
 The following installed packages were additionally loaded to satisfy runtime dependencies
   grault

--- a/testing/baselines/tests.info/foo.info
+++ b/testing/baselines/tests.info/foo.info
@@ -1,12 +1,12 @@
 "one/alice/foo" info:
 	versions: ['1.0.0', '1.0.1', '1.0.2']
 	install status:
-		current_version = master
+		current_version = main
 		is_loaded = True
 		is_outdated = True
 		is_pinned = False
 		tracking_method = branch
 	metadata file: /Users/jon/pro/zeek/package-manager/testing/.tmp/tests.info/state/clones/package/foo/zkg.meta
-	metadata (from version "master"):
+	metadata (from version "main"):
 		<empty metadata file>
 

--- a/testing/baselines/tests.info/installed.info
+++ b/testing/baselines/tests.info/installed.info
@@ -1,12 +1,12 @@
 "one/alice/foo" info:
 	versions: ['1.0.0', '1.0.1', '1.0.2']
 	install status:
-		current_version = master
+		current_version = main
 		is_loaded = True
 		is_outdated = True
 		is_pinned = False
 		tracking_method = branch
 	metadata file: /Users/jon/pro/zeek/package-manager/testing/.tmp/tests.info/state/clones/package/foo/zkg.meta
-	metadata (from version "master"):
+	metadata (from version "main"):
 		<empty metadata file>
 

--- a/testing/baselines/tests.list/installed.out
+++ b/testing/baselines/tests.list/installed.out
@@ -1,2 +1,2 @@
 one/alice/bar (installed: master)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.list/loaded.out
+++ b/testing/baselines/tests.list/loaded.out
@@ -1,1 +1,1 @@
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.list/outdated.out
+++ b/testing/baselines/tests.list/outdated.out
@@ -1,1 +1,1 @@
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.load-zeek-dependency/foo-loaded.out
+++ b/testing/baselines/tests.load-zeek-dependency/foo-loaded.out
@@ -1,1 +1,1 @@
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.metadata-depends/bundle_depends.out
+++ b/testing/baselines/tests.metadata-depends/bundle_depends.out
@@ -1,5 +1,5 @@
 one/alice/bar (installed: 1.0.0)
 one/alice/baz (installed: 2.0.0)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/bob/corge (installed: 1.0.1)
 one/bob/grault (installed: master)

--- a/testing/baselines/tests.metadata-depends/install_depends.out
+++ b/testing/baselines/tests.metadata-depends/install_depends.out
@@ -1,5 +1,5 @@
 one/alice/bar (installed: 1.0.0)
 one/alice/baz (installed: 2.0.0)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/bob/corge (installed: 1.0.1)
 one/bob/grault (installed: master)

--- a/testing/baselines/tests.metadata-depends/no_depends.out
+++ b/testing/baselines/tests.metadata-depends/no_depends.out
@@ -1,1 +1,1 @@
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.metadata-depends/upgrade_depends.out
+++ b/testing/baselines/tests.metadata-depends/upgrade_depends.out
@@ -1,5 +1,5 @@
 one/alice/bar (installed: 1.0.0)
 one/alice/baz (installed: 2.0.0)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/bob/corge (installed: 1.0.1)
 one/bob/grault (installed: master)

--- a/testing/baselines/tests.metadata-suggests/bundle_suggests.out
+++ b/testing/baselines/tests.metadata-suggests/bundle_suggests.out
@@ -1,5 +1,5 @@
 one/alice/bar (installed: 1.0.0)
 one/alice/baz (installed: 2.0.0)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/bob/corge (installed: 1.0.1)
 one/bob/grault (installed: master)

--- a/testing/baselines/tests.metadata-suggests/install_suggests.out
+++ b/testing/baselines/tests.metadata-suggests/install_suggests.out
@@ -1,5 +1,5 @@
 one/alice/bar (installed: 1.0.0)
 one/alice/baz (installed: 2.0.0)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/bob/corge (installed: 1.0.1)
 one/bob/grault (installed: master)

--- a/testing/baselines/tests.metadata-suggests/no_suggests.out
+++ b/testing/baselines/tests.metadata-suggests/no_suggests.out
@@ -1,1 +1,1 @@
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.metadata-suggests/upgrade_suggests.out
+++ b/testing/baselines/tests.metadata-suggests/upgrade_suggests.out
@@ -1,5 +1,5 @@
 one/alice/bar (installed: 1.0.0)
 one/alice/baz (installed: 2.0.0)
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/bob/corge (installed: 1.0.1)
 one/bob/grault (installed: master)

--- a/testing/baselines/tests.refresh/list.out
+++ b/testing/baselines/tests.refresh/list.out
@@ -1,7 +1,7 @@
 one/alice/bad_pkg
 one/alice/bar
 one/alice/baz
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/alice/i-have-no-scripts
 one/alice/new_pkg
 one/alice/qux

--- a/testing/baselines/tests.refresh/list_after_agg.out
+++ b/testing/baselines/tests.refresh/list_after_agg.out
@@ -1,7 +1,7 @@
 one/alice/bad_pkg
 one/alice/bar
 one/alice/baz
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)
 one/alice/i-have-no-scripts
 one/alice/new_pkg - This is the new_pkg package description
 one/alice/qux

--- a/testing/baselines/tests.refresh/outdated.out
+++ b/testing/baselines/tests.refresh/outdated.out
@@ -1,1 +1,1 @@
-one/alice/foo (installed: master)
+one/alice/foo (installed: main)

--- a/testing/baselines/tests.refresh/search.out
+++ b/testing/baselines/tests.refresh/search.out
@@ -1,2 +1,2 @@
-one/alice/foo (installed: master) - This is the foo package description
+one/alice/foo (installed: main) - This is the foo package description
 one/alice/new_pkg - This is the new_pkg package description

--- a/testing/scripts/initializer
+++ b/testing/scripts/initializer
@@ -3,7 +3,12 @@
 cp -R $PACKAGES .
 
 for p in packages/*; do
-    ( cd $p && git init && git add * && git commit -m 'init' )
+    if [ $p = 'packages/foo' ]; then
+        # Use a different default branch than 'master' for testing purposes
+        ( cd $p && git init && git checkout -b main && git add * && git commit -m 'init' )
+    else
+        ( cd $p && git init && git add * && git commit -m 'init' )
+    fi
 done
 
 cp -R $SOURCES .

--- a/testing/scripts/initializer
+++ b/testing/scripts/initializer
@@ -16,11 +16,12 @@ done
 
 # Create a branch drop-corge in source "one" to drop corge from index
 ( cd sources/one &&
+  default_branch=$(git rev-parse --abbrev-ref HEAD) &&
   git checkout -b drop-corge &&
   sed -i -e '/corge/d' bob/zkg.index &&
   git add ./bob/zkg.index &&
   git commit -m 'Remove corge' &&
-  git checkout master )
+  git checkout ${default_branch} )
 
 echo "\
 [sources]

--- a/testing/tests/bundle
+++ b/testing/tests/bundle
@@ -19,6 +19,12 @@
 # @TEST-EXEC: zkg list installed > manifest.out
 # @TEST-EXEC: btest-diff manifest.out
 
+default_branch_name=$( cd packages/baz && git rev-parse --abbrev-ref HEAD )
+echo "[bundle]" > manifest.txt
+echo "foo = 1.0.0" >> manifest.txt
+echo "bar = 1.0.1" >> manifest.txt
+echo "baz = ${default_branch_name}" >> manifest.txt
+
 cd packages/foo
 echo 'print "foo 1.0.0";' > __load__.zeek
 git commit -am 'new stuff'
@@ -40,10 +46,3 @@ git tag -a 1.0.1 -m 1.0.1
 echo 'print "bar 1.0.2";' > __load__.zeek
 git commit -am 'new stuff'
 git tag -a 1.0.2 -m 1.0.2
-
-@TEST-START-FILE manifest.txt
-[bundle]
-foo = 1.0.0
-bar = 1.0.1
-baz = master
-@TEST-END-FILE

--- a/testing/tests/install
+++ b/testing/tests/install
@@ -16,7 +16,8 @@
 # @TEST-EXEC: btest-diff scripts/packages/corge/__load__.zeek
 
 # @TEST-EXEC: zkg remove corge
-# @TEST-EXEC: zkg install corge --version=master
+# @TEST-EXEC: ( cd $(pwd)/packages/corge && git rev-parse --abbrev-ref HEAD ) > default_branch_name
+# @TEST-EXEC: zkg install corge --version=$(cat default_branch_name)
 # @TEST-EXEC: cp scripts/packages/corge/__load__.zeek corge.master
 # @TEST-EXEC: btest-diff corge.master
 

--- a/testing/tests/metadata-depends
+++ b/testing/tests/metadata-depends
@@ -29,8 +29,10 @@ echo 'depends = baz >=1.0.0' >> zkg.meta
 git commit -am 'new stuff'
 git tag -a 1.0.0 -m 1.0.0
 
+default_branch_name=$( cd ../grault && git rev-parse --abbrev-ref HEAD )
+
 cd ../baz
-echo 'depends = grault branch=master' >> zkg.meta
+echo "depends = grault branch=${default_branch_name}" >> zkg.meta
 git commit -am 'new stuff'
 git tag -a 1.0.0 -m 1.0.0
 echo 'print "2.0.0";' > __load__.zeek

--- a/testing/tests/metadata-suggests
+++ b/testing/tests/metadata-suggests
@@ -29,8 +29,10 @@ echo 'suggests = baz >=1.0.0' >> zkg.meta
 git commit -am 'new stuff'
 git tag -a 1.0.0 -m 1.0.0
 
+default_branch_name=$( cd ../grault && git rev-parse --abbrev-ref HEAD )
+
 cd ../baz
-echo 'suggests = grault branch=master' >> zkg.meta
+echo "suggests = grault branch=${default_branch_name}" >> zkg.meta
 git commit -am 'new stuff'
 git tag -a 1.0.0 -m 1.0.0
 echo 'print "2.0.0";' > __load__.zeek

--- a/testing/tests/search-extra
+++ b/testing/tests/search-extra
@@ -1,4 +1,4 @@
-# First search for corge in source one master
+# First search for corge in source one default branch (i.e. 'master' or 'main')
 #
 # @TEST-EXEC: zkg search corge > search.out
 # @TEST-EXEC: grep -q -m 1 'one/bob/corge' search.out
@@ -15,6 +15,7 @@
 # @TEST-EXEC: zkg search quux > search.out
 # @TEST-EXEC: grep -m 1 'no matches' search.out
 #
-# Now in source two with explicit master branch
-# @TEST-EXEC: zkg --extra-source two=`pwd`/sources/two@master search quux > search.out
+# Now in source two with explicit branch (i.e. using the default of 'master' or 'main')
+# @TEST-EXEC: ( cd $(pwd)/sources/two && git rev-parse --abbrev-ref HEAD ) > default_branch_name
+# @TEST-EXEC: zkg --extra-source two=`pwd`/sources/two@$(cat default_branch_name) search quux > search.out
 # @TEST-EXEC: grep -m 1 'two/eve/quux' search.out

--- a/zeekpkg/package.py
+++ b/zeekpkg/package.py
@@ -240,7 +240,7 @@ class PackageInfo(object):
 
     def __init__(self, package=None, status=None, metadata=None, versions=None,
                  metadata_version='', invalid_reason='', version_type='',
-                 metadata_file=None):
+                 metadata_file=None, default_branch=None):
         self.package = package
         self.status = status
         self.metadata = {} if metadata is None else metadata
@@ -249,6 +249,7 @@ class PackageInfo(object):
         self.version_type = version_type
         self.invalid_reason = invalid_reason
         self.metadata_file = metadata_file
+        self.default_branch = default_branch
 
     def aliases(self):
         """Return a list of package name aliases.
@@ -298,12 +299,12 @@ class PackageInfo(object):
         """Returns the best/latest version of the package that is available.
 
         If the package has any git release tags, this returns the highest one,
-        else it returns the 'master' branch.
+        else it returns the default branch like 'main' or 'master'.
         """
         if self.versions:
             return self.versions[-1]
 
-        return 'master'
+        return self.default_branch
 
 
 class Package(object):

--- a/zeekpkg/source.py
+++ b/zeekpkg/source.py
@@ -21,6 +21,7 @@ from .package import (
     Package
 )
 from ._util import (
+    git_default_branch,
     git_checkout,
     git_clone
 )
@@ -81,9 +82,7 @@ class Source(object):
                 shutil.rmtree(clone_path)
                 self.clone = git_clone(git_url, clone_path, shallow=True)
 
-        # Hmm, maybe this needs to be configurable for people that
-        # use differently named master branches...
-        git_checkout(self.clone, version or "master")
+        git_checkout(self.clone, version or git_default_branch(self.clone))
 
     def __str__(self):
         return self.git_url

--- a/zkg
+++ b/zkg
@@ -2010,8 +2010,8 @@ def argparser():
         ' If the package name refers to a local git repo with a working tree,'
         ' then its currently active branch is used.'
         ' The default for other cases is to use'
-        ' the latest version tag, or if a package has none, the "master"'
-        ' branch.')
+        ' the latest version tag, or if a package has none,'
+        ' the default branch, like "main" or "master".')
 
     # install
     sub_parser = command_parser.add_parser(
@@ -2046,8 +2046,8 @@ def argparser():
         ' If the package name refers to a local git repo with a working tree,'
         ' then its currently active branch is used.'
         ' The default for other cases is to use'
-        ' the latest version tag, or if a package has none, the "master"'
-        ' branch.')
+        ' the latest version tag, or if a package has none,'
+        ' the default branch, like "main" or "master".')
 
     # bundle
     sub_parser = command_parser.add_parser(
@@ -2167,7 +2167,7 @@ def argparser():
         ' clone of the package'
         ' source that zkg uses internally locating package metadata.'
         ' For each package, the metadata is taken from the highest available'
-        ' git version tag or the master branch if no version tags exist')
+        ' git version tag or the default branch, like "main" or "master", if no version tags exist')
     sub_parser.add_argument(
         '--push', action='store_true',
         help='Push all local changes to package sources to upstream repos')
@@ -2319,7 +2319,7 @@ def argparser():
         ' on whether the package is currently installed.  If installed,'
         ' the metadata will be pulled from the installed version.  If not'
         ' installed, the latest version tag is used, or if a package has no'
-        ' version tags, the "master" branch is used.')
+        ' version tags, the default branch, like "main" or "master", is used.')
     sub_parser.add_argument(
         '--nolocal', action='store_true',
         help='Do not read information from locally installed packages.'

--- a/zkg.config
+++ b/zkg.config
@@ -15,7 +15,8 @@
 # additional sources may be added as long as they use a unique key
 # and a value that is a valid git URL.  The git URL may also use a
 # suffix like "@branch-name" where "branch-name" is the name of a real
-# branch to checkout (as opposed to the default "master" branch).
+# branch to checkout (as opposed to the default branch, which is typically
+# "main" or "master").
 zeek = https://github.com/zeek/packages
 
 [paths]


### PR DESCRIPTION
Fixes #76 

Could use a sanity check/review to see if I missed anything important like:
* Is there actually some concept of a "default" branch that can be used in absence of a remote HEAD reference ?
* Whether change in default branch selection logic disrupts any particular use-case in a notable/likely way (my guess is 'no'): read commit message of https://github.com/zeek/package-manager/commit/99a3951ec8f74579ef0e0e04f2bb37d617b31918 for exactly what the logic now looks like