### PR TITLE
Replace remaining use of Thread.isAlive with Thread.is_alive

### DIFF
--- a/zkg
+++ b/zkg
@@ -1279,7 +1279,7 @@ def cmd_upgrade(manager, args, config, configfile):
         worker = InstallWorker(manager, name, version)
         worker.start()
 
-        while worker.isAlive():
+        while worker.is_alive():
             worker.join(join_timeout)
             time_accumulator += join_timeout
 


### PR DESCRIPTION
isAlive() has been deprecated for a while. Python 3.9 (Fedora 33's default) no longer includes it, which broke the metadata-depends and metadata-suggests tests.

I guess we could consider broadening zkg's CI so it's in line with our platform support policy ...