### PR TITLE
Add the Zeek bin directory to PATH by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(zkg)
 
+set(ZEEK_BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
 set(orig_file ${CMAKE_CURRENT_SOURCE_DIR}/zkg)
 set(configed_file ${CMAKE_CURRENT_BINARY_DIR}/zkg)
 configure_file(${orig_file} ${configed_file} @ONLY)

--- a/zkg
+++ b/zkg
@@ -44,7 +44,7 @@ ZEEK_BIN_DIR = '@ZEEK_BIN_DIR@'
 if os.path.isdir(ZEEK_BIN_DIR):
     try:
         if ZEEK_BIN_DIR not in os.environ['PATH'].split(os.pathsep):
-            os.environ['PATH'] += os.pathsep + ZEEK_BIN_DIR
+            os.environ['PATH'] = ZEEK_BIN_DIR + os.pathsep + os.environ['PATH']
     except KeyError:
         os.environ['PATH'] = ZEEK_BIN_DIR
 else:

--- a/zkg
+++ b/zkg
@@ -37,6 +37,19 @@ if os.path.isdir(ZEEK_PYTHON_DIR):
 else:
     ZEEK_PYTHON_DIR = None
 
+# Similarly, make Zeek's binary installation path available by
+# default. This helps package installations succeed that require
+# e.g. zeek-config for their build process.
+ZEEK_BIN_DIR = '@ZEEK_BIN_DIR@'
+if os.path.isdir(ZEEK_BIN_DIR):
+    try:
+        if ZEEK_BIN_DIR not in os.environ['PATH']:
+            os.environ['PATH'] += os.pathsep + ZEEK_BIN_DIR
+    except KeyError:
+        os.environ['PATH'] = ZEEK_BIN_DIR
+else:
+    ZEEK_BIN_DIR = None
+
 # Also when bundling with Zeek, use directories in the install tree
 # for storing the zkg configuration and its variable state:
 ZEEK_ZKG_CONFIG_DIR = '@ZEEK_ZKG_CONFIG_DIR@'

--- a/zkg
+++ b/zkg
@@ -43,7 +43,7 @@ else:
 ZEEK_BIN_DIR = '@ZEEK_BIN_DIR@'
 if os.path.isdir(ZEEK_BIN_DIR):
     try:
-        if ZEEK_BIN_DIR not in os.environ['PATH']:
+        if ZEEK_BIN_DIR not in os.environ['PATH'].split(os.pathsep):
             os.environ['PATH'] += os.pathsep + ZEEK_BIN_DIR
     except KeyError:
         os.environ['PATH'] = ZEEK_BIN_DIR


### PR DESCRIPTION
This helps package installations succeed that require executables from that directory, such as zeek-config. @0xxon noticed this in her package-making adventures. For testing, I removed my installation's bin directory from my PATH and a plugin-package needing `zeek-config` installed fine with the fix (and indeed doesn't otherwise).