### PR TITLE
Increase robustness with local githooks

### DIFF
--- a/testing/btest.cfg
+++ b/testing/btest.cfg
@@ -7,6 +7,7 @@ BaselineDir = baselines
 Initializer = %(testbase)s/scripts/initializer
 
 [environment]
+ORIGPATH=%(default_path)s
 PATH=%(testbase)s/scripts:%(default_path)s
 SCRIPTS=%(testbase)s/scripts
 SOURCES=%(testbase)s/sources

--- a/testing/scripts/git
+++ b/testing/scripts/git
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+# Git wrapper script for use during testing.
+
+# Use original path so we find the system's installed git, not this wrapper.
+PATH="$ORIGPATH"
+
+# Unsetting the following prevents git from reading ~/.gitconfig,
+# including potential githooks.
+HOME=
+XDG_CONFIG_HOME=
+
+git -c user.name=zkg -c user.email=zkg@zeek.org "$@"

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -888,9 +888,9 @@ class Manager(object):
 
             if source.clone.is_dirty():
                 source.clone.git.commit(
-                    '--message', 'Update aggregated metadata.')
+                    '--no-verify', '--message', 'Update aggregated metadata.')
 
-            source.clone.git.push()
+            source.clone.git.push('--no-verify')
 
         return self.SourceAggregationResults('', aggregation_issues)
 


### PR DESCRIPTION
I've been tinkering with local git (pre-)commit hooks and by accident noticed that those can interfere with zkg in two ways: (1) package source updates when using `zkg refresh --aggregate --push`, (2) running the testsuite.

The former will look something like this:
```
$ zkg refresh --aggregate --push --sources ckreibich
Refresh package source: ckreibich
Traceback (most recent call last):
  File "/home/christian/inst/opt/zeek/bin/zkg", line 2511, in <module>
    main()
  File "/home/christian/inst/opt/zeek/bin/zkg", line 2508, in main
    args.run_cmd(manager, args, config, configfile)
  File "/home/christian/inst/opt/zeek/bin/zkg", line 1117, in cmd_refresh
    res = manager.aggregate_source(source, args.push)
  File "/home/christian/inst/opt/zeek/lib64/zeek/python/zeekpkg/manager.py", line 724, in aggregate_source
    return self._refresh_source(name, True, push)
  File "/home/christian/inst/opt/zeek/lib64/zeek/python/zeekpkg/manager.py", line 890, in _refresh_source
    source.clone.git.commit(
  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 542, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 1005, in _call_process
    return self.execute(call, **exec_kwargs)
  File "/usr/lib/python3.9/site-packages/git/cmd.py", line 822, in execute
    raise GitCommandError(command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  cmdline: git commit --message Update aggregated metadata.
  stderr: 'aggregate.meta:3: trailing whitespace.
+depends = 
aggregate.meta:11: new blank line at EOF.
Pre-commit hook /home/christian/.githooks/pre-commit.d/git.sh rejected commit, exit code 2'
```
The latter like this:
```
$ btest -c btest.cfg 
[ 56%] tests.package_base ... failed
[ 62%] tests.plugin ... failed
[ 65%] tests.plugin_tarfile ... failed
[ 84%] tests.test ... failed
4 of 32 tests failed
$ cat .tmp/tests.package_base/.stderr 
Switched to a new branch 'main'
scripts/Demo/Rot13/__load__.zeek:4: trailing whitespace.
+# 
scripts/__load__.zeek:4: trailing whitespace.
+# 
scripts/__preload__.zeek:3: trailing whitespace.
+# plugin defines become available. 
scripts/__preload__.zeek:4: trailing whitespace.
+# 
scripts/__preload__.zeek:7: trailing whitespace.
+# elemets), that should go into __load__.zeek instead.   
scripts/__preload__.zeek:8: trailing whitespace.
+# 
scripts/__preload__.zeek:11: new blank line at EOF.
testing/tests/main:3: new blank line at EOF.
Pre-commit hook /home/christian/.githooks/pre-commit.d/git.sh rejected commit, exit code 2
Switched to a new branch 'drop-corge'
Switched to branch 'master'
zkg.meta:2: trailing whitespace.
+build_command = cd "%(package_base)s" && ls 
Pre-commit hook /home/christian/.githooks/pre-commit.d/git.sh rejected commit, exit code 2
```
You could argue "well don't do that then!" ... but `zkg`'s git use is technically internal, so the user's personal hooks shouldn't interfere. I'm adding two things here:
- For the testsuite, a git wrapper script avoids `~/.gitconfig` completely. I like this also because it avoids other user artifacts (like email address and name) showing up in test-related git repos. You'd still hits local hooks if they're configured system-wide.
- For `zkg` itself I'm simply adding `--no-verify` to a few git invocations. This isn't a complete solution but keeps the change small. 

An alternative approach would be to pass `-c core.hooksPath=/dev/null` to git invocations more broadly, which would be more invasive but also more focused on local hooks.