### PR TITLE
Fix crash in case the user enters just "zkg template"

### DIFF
--- a/zkg
+++ b/zkg
@@ -2646,8 +2646,9 @@ def argparser():
         'template', help='Manage package templates.')
 
     template_command_parser = sub_parser.add_subparsers(
-        title='template commands',
-        help='See `%(prog)s template <command> -h for per-command usage info.')
+        title='template commands', dest='command',
+        help='See %(prog)s <command> -h for per-command usage info.')
+    template_command_parser.required = True
 
     # template info
 


### PR DESCRIPTION
@bbannier flagged a backtrace when the user didn't go straight to a `zkg template` subcommand ... which apparently I never noticed. :facepalm: 

The output of "zkg template" (which will gain various commands over time) now mirrors that when just saying "zkg". Also, the help output in `zkg template --help` no longer double-mentions "template".