### PR TITLE
Require zeek-config for two tests that will fail without it

### DIFF
--- a/testing/tests/bindir-install
+++ b/testing/tests/bindir-install
@@ -1,3 +1,6 @@
+# "zkg test" internally requires zeek-config
+# @TEST-REQUIRES: type zeek-config
+
 # @TEST-EXEC: bash %INPUT
 #
 # @TEST-EXEC: zkg test foo

--- a/testing/tests/test
+++ b/testing/tests/test
@@ -1,3 +1,6 @@
+# "zkg test" internally requires zeek-config
+# @TEST-REQUIRES: type zeek-config
+
 # @TEST-EXEC: bash %INPUT
 # @TEST-EXEC: zkg test rot13
 


### PR DESCRIPTION
"zkg test" constructs a suitable test environment via zeek-config's output.

It also needs zeek-config when constructing package dependencies, so it can verify whether packages depending on specific Zeek versions will work. So I'm surprised the absence doesn't trip up more tests. :grimacing: 