### PR TITLE
Add TEST-REQUIRES for zeek-config to three tests that require it

### DIFF
--- a/testing/tests/dependency-ordering
+++ b/testing/tests/dependency-ordering
@@ -13,6 +13,10 @@
 # & test call executables that bar and baz install; baz's build & test call
 # corge's executable, bar and corge call grault's executable.
 
+# We trigger package tests in the below, for which zkg internally looks
+# for zeek-config. So require a Zeek install:
+# @TEST-REQUIRES: type zeek-config
+
 # @TEST-EXEC: BUILDLOG=$(pwd)/build.log bash %INPUT
 
 # After testing, the packages get installed up the dependency chain, installing

--- a/testing/tests/package_base
+++ b/testing/tests/package_base
@@ -1,3 +1,7 @@
+# This test involves package testing, for which zkg internally requires
+# zeek-config. So require a Zeek install:
+# @TEST-REQUIRES: type zeek-config
+
 # @TEST-EXEC: bash %INPUT
 
 # @TEST-EXEC: zkg install foo

--- a/testing/tests/user_vars
+++ b/testing/tests/user_vars
@@ -1,3 +1,7 @@
+# This test involves package testing, for which zkg internally requires
+# zeek-config. So require a Zeek install:
+# @TEST-REQUIRES: type zeek-config
+
 # @TEST-EXEC: bash %INPUT
 
 # @TEST-EXEC: LAST_VAR=/home/jon/sandbox zkg install foo


### PR DESCRIPTION
These would previously fail without a Zeek installation.