### PR TITLE
Request at least Sphinx 2.0 to avoid a dependency problem in RTD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ GitPython
 semantic_version
 btest
 # Requirements for development (e.g. building docs)
-Sphinx
+Sphinx>=2.0
 sphinxcontrib-napoleon
 sphinx_rtd_theme


### PR DESCRIPTION
This resolves the build problems due to sphinx-doc/sphinx#9727 we've been seeing e.g. here:
https://readthedocs.org/projects/bro-package-manager/builds/15177099/

Working build here: https://readthedocs.org/projects/bro-package-manager/builds/15177411/