### PR TITLE
Switch to the sphinx-bundled version of the Napoleon add-on

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.abspath('./ext'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxarg.ext', 'sphinx.ext.autodoc', 'sphinxcontrib.napoleon']
+extensions = ['sphinxarg.ext', 'sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ GitPython
 semantic_version
 btest
 # Requirements for development (e.g. building docs)
-Sphinx>=2.0
-sphinxcontrib-napoleon
+Sphinx>=3.0
 sphinx_rtd_theme


### PR DESCRIPTION
The Sphinx Napoleon add-on is hitting trouble with Python 3.10:

https://github.com/sphinx-contrib/napoleon/pull/36

The fix is not yet released, meaning the only way to get the zkg docs to build
atm is to install the add-on from their master branch.

Per https://pypi.org/project/sphinxcontrib-napoleon/, Napoleon is bundled with
Sphinx 1.3 (released March 2015), so this switches to the included version.