### PR TITLE
Make Zeek-provided CMake modules available to packages.

### DIFF
--- a/testing/baselines/tests.user-mode/output
+++ b/testing/baselines/tests.user-mode/output
@@ -8,6 +8,7 @@ script_dir = <...>/zeekroot/share/zeek/site
 plugin_dir = <...>/zeekroot/lib/zeek/plugins
 bin_dir = <...>/zeekroot/var/lib/zkg/bin
 zeek_dist = 
+cmake_dir = 
 
 [templates]
 default = https://github.com/zeek/package-template
@@ -30,6 +31,7 @@ script_dir = <...>/home/testuser/.zkg/script_dir
 plugin_dir = <...>/home/testuser/.zkg/plugin_dir
 bin_dir = <...>/home/testuser/.zkg/bin
 zeek_dist = 
+cmake_dir = 
 
 [templates]
 default = https://github.com/zeek/package-template

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -231,7 +231,7 @@ class Manager(object):
             load all installed packages that have been marked as loaded.
     """
 
-    def __init__(self, state_dir, script_dir, plugin_dir, zeek_dist='',
+    def __init__(self, state_dir, script_dir, plugin_dir, cmake_dir, zeek_dist='',
                  user_vars=None, bin_dir=''):
         """Creates a package manager instance.
 
@@ -241,6 +241,8 @@ class Manager(object):
             script_dir (str): value to set the `script_dir` attribute to
 
             plugin_dir (str): value to set the `plugin_dir` attribute to
+
+            cmake_dir (str): value to set the `cmake_dir` attribute to
 
             zeek_dist (str): value to set the `zeek_dist` attribute to
 
@@ -261,6 +263,7 @@ class Manager(object):
         # The bro_dist attribute exists just for backward compatibility
         self.bro_dist = zeek_dist
         self.zeek_dist = zeek_dist
+        self.cmake_dir = cmake_dir
         self.state_dir = state_dir
         self.user_vars = {} if user_vars is None else user_vars
         self.backup_dir = os.path.join(self.state_dir, 'backups')

--- a/zkg
+++ b/zkg
@@ -277,11 +277,22 @@ def create_config(args, configfile):
     if not zeek_dist:
         zeek_dist = get_option(config, 'paths', 'bro_dist', '')
 
+    cmake_dir = get_option(config, 'paths', 'cmake_dir', '')
+
+    if cmake_dir:
+        # If a cmake_dir is set, inject it into any CMake invocations created
+        # from this processess via `CMAKE_PREFIX_PATH`. This allows packages to
+        # use Zeek-provided CMake modules. We append to any existing settings
+        # in the caller's environment, so existing setting keep precedence.
+        cmake_prefix_path = os.environ.get('CMAKE_PREFIX_PATH', '')
+        os.environ['CMAKE_PREFIX_PATH'] = ';'.join([cmake_prefix_path, cmake_dir])
+
     config.set('paths', 'state_dir', state_dir)
     config.set('paths', 'script_dir', script_dir)
     config.set('paths', 'plugin_dir', plugin_dir)
     config.set('paths', 'bin_dir', bin_dir)
     config.set('paths', 'zeek_dist', zeek_dist)
+    config.set('paths', 'cmake_dir', cmake_dir)
 
     def expand_config_values(config, section):
         for key, value in config.items(section):
@@ -367,6 +378,7 @@ def create_manager(args, config):
     script_dir = config.get('paths', 'script_dir')
     plugin_dir = config.get('paths', 'plugin_dir')
     bin_dir = config.get('paths', 'bin_dir')
+    cmake_dir = config.get('paths', 'cmake_dir')
     zeek_dist = config.get('paths', 'zeek_dist')
 
     if state_dir == default_state_dir():
@@ -376,7 +388,7 @@ def create_manager(args, config):
     try:
         manager = zeekpkg.Manager(state_dir=state_dir, script_dir=script_dir,
                                  plugin_dir=plugin_dir, bin_dir=bin_dir,
-                                 zeek_dist=zeek_dist)
+                                 cmake_dir=cmake_dir, zeek_dist=zeek_dist)
     except (OSError, IOError) as error:
         if error.errno == errno.EACCES:
             print_error('{}: {}'.format(type(error).__name__, error))
@@ -1956,7 +1968,7 @@ def cmd_autoconfig(manager, args, config, configfile):
     dist_option = '--zeek_dist' if have_zeek_config else '--bro_dist'
 
     cmd = subprocess.Popen([zeek_config,
-                            '--site_dir', '--plugin_dir', '--prefix', dist_option],
+                            '--site_dir', '--plugin_dir', '--prefix', dist_option, '--cmake_dir'],
                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                            bufsize=1, universal_newlines=True)
 
@@ -1964,6 +1976,7 @@ def cmd_autoconfig(manager, args, config, configfile):
     plugin_dir = read_zeek_config_line(cmd.stdout)
     bin_dir = os.path.join(read_zeek_config_line(cmd.stdout), 'bin')
     zeek_dist = read_zeek_config_line(cmd.stdout)
+    cmake_dir = read_zeek_config_line(cmd.stdout)
 
     if configfile:
         config_dir = os.path.dirname(configfile)
@@ -1980,7 +1993,10 @@ def cmd_autoconfig(manager, args, config, configfile):
             config.set(section, option, new_value)
             return
 
-        old_value = config.get(section, option)
+        try:
+            old_value = config.get(section, option)
+        except configparser.NoOptionError:
+            old_value = '<unset>'
 
         if old_value == new_value:
             return
@@ -2001,6 +2017,8 @@ def cmd_autoconfig(manager, args, config, configfile):
                         bin_dir, config_file_exists)
     change_config_value(config, 'paths', 'zeek_dist',
                         zeek_dist, config_file_exists)
+    change_config_value(config, 'paths', 'cmake_dir',
+                        cmake_dir, config_file_exists)
 
     with io.open(configfile, 'w', encoding=std_encoding(sys.stdout)) as f:
         config.write(f)


### PR DESCRIPTION
With this patch we make Zeek-provided CMake modules discoverable by
CMake invocations in package script instructions, specifically we append
the directory exposed by `zeek-config --cmake_dir` in the environment
variable `CMAKE_PREFIX_PATH`. If the environment variable is already set
we append to it, so any existing settings take precedence. If script
instructions modify this variable they will find the same CMake modules
if they prepend to the environment variable.

We inject the environment variable by setting it for the whole `zkg`
process at a pretty high level so that it is inherited by any forked
processes like e.g., shells spawned for package script instructions.
Ideally we would use a more general mechanism to set up the environment
for script instructions so that we can use an identical mechanism for
e.g., `PATH`, `CMAKE_PREFIX_PATH` and any future additions.

We also add persistence for this setting by adding it to the zkg
`config` file under `paths.cmake_dir`. Before this patch all variables
in the `paths` section referred to target paths for user settings or
packages (state, script, plugin directory), so this might not be the
optimal ultimate format to store this information.