### PR TITLE
Add safety wrapper around tarfile.extractall() — refactored version of #142

### DIFF
--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -6,6 +6,7 @@ import errno
 import importlib.machinery
 import os
 import shutil
+import tarfile
 import types
 
 import git
@@ -64,6 +65,38 @@ def make_symlink(target_path, link_path, force=True):
             os.symlink(target_path, link_path)
         else:
             raise error
+
+
+def safe_tarfile_extractall(tfile, destdir):
+    """Wrapper to tarfile.extractall(), checking for path traversal.
+
+    This adds the safeguards the Python docs for tarfile.extractall warn about:
+
+    Never extract archives from untrusted sources without prior inspection. It
+    is possible that files are created outside of path, e.g. members that have
+    absolute filenames starting with "/" or filenames with two dots "..".
+
+    Args:
+        tfile (str): the tar file to extract
+
+        destdir (str): the destination directory into which to place contents
+
+    Raises:
+        Exception: if the tarfile would extract outside destdir
+    """
+    def is_within_directory(directory, target):
+        abs_directory = os.path.abspath(directory)
+        abs_target = os.path.abspath(target)
+        prefix = os.path.commonprefix([abs_directory, abs_target])
+        return prefix == abs_directory
+
+    with tarfile.open(tfile) as tar:
+        for member in tar.getmembers():
+            member_path = os.path.join(destdir, member.name)
+            if not is_within_directory(destdir, member_path):
+                raise Exception('attempted path traversal in tarfile')
+
+        tar.extractall(destdir)
 
 
 def find_sentence_end(s):

--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -276,6 +276,7 @@ def find_program(prog_name):
 
     return ''
 
+
 def std_encoding(stream):
     if stream.encoding:
         return stream.encoding
@@ -286,6 +287,7 @@ def std_encoding(stream):
         return 'utf-8'
 
     return locale.getpreferredencoding()
+
 
 def read_zeek_config_line(stdout):
     return stdout.readline().strip()
@@ -306,6 +308,7 @@ def get_zeek_version():
                            bufsize=1, universal_newlines=True)
 
     return read_zeek_config_line(cmd.stdout)
+
 
 def load_source(filename):
     """Loads given Python script from disk.
@@ -328,6 +331,7 @@ def load_source(filename):
     loader.exec_module(mod)
 
     return mod
+
 
 def configparser_section_dict(parser, section):
     """Returns a dict representing a ConfigParser section.

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -40,6 +40,7 @@ from ._util import (
     read_zeek_config_line,
     normalize_version_tag,
     configparser_section_dict,
+    safe_tarfile_extractall,
 )
 from .source import (
     AGGREGATE_DATA_FILE,
@@ -1572,8 +1573,7 @@ class Manager(object):
         infos = []
 
         try:
-            with tarfile.open(bundle_file) as tf:
-                tf.extractall(bundle_dir)
+            safe_tarfile_extractall(bundle_file, bundle_dir)
         except Exception as error:
             return (str(error), infos)
 
@@ -2278,8 +2278,7 @@ class Manager(object):
         make_dir(bundle_dir)
 
         try:
-            with tarfile.open(bundle_file) as tf:
-                tf.extractall(bundle_dir)
+            safe_tarfile_extractall(bundle_file, bundle_dir)
         except Exception as error:
             return str(error)
 
@@ -2908,8 +2907,7 @@ def _copy_package_dir(package, dirname, src, dst, scratch_dir):
         make_dir(tmp_dir)
 
         try:
-            with tarfile.open(src) as tf:
-                tf.extractall(tmp_dir)
+            safe_tarfile_extractall(src, tmp_dir)
         except Exception as error:
             return str(error)
 


### PR DESCRIPTION
This refactors #142 to better suit our codebase. It also calls out that the Python docs do in fact warn about this setting.