### PR TITLE
Fix git complaint about unsafe use of file protocol in submodule test

### DIFF
--- a/testing/scripts/git
+++ b/testing/scripts/git
@@ -10,6 +10,7 @@ HOME=
 XDG_CONFIG_HOME=
 
 git -c init.defaultBranch=master \
+    -c protocol.file.allow=always \
     -c user.name=zkg \
     -c user.email=zkg@zeek.org \
     "$@"


### PR DESCRIPTION
This allows the `package-submodule` test to succeed when it would otherwise complain with a "fatal: transport 'file' not allowed" error. This is with git 2.38.1 on my local system.

https://git-scm.com/docs/git-config#Documentation/git-config.txt-protocolallow