### PR TITLE
Tweaks to appease CodeQL

### DIFF
--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -193,7 +193,7 @@ def git_default_branch(repo):
         # Technically possible that remote has no HEAD, so guard against that.
         try:
             head_ref_name = remote.refs.HEAD.ref.name
-        except:
+        except Exception:
             head_ref_name = None
 
         if head_ref_name:

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -526,7 +526,6 @@ class Manager(object):
 
         # Support @ in the path to denote the "version" to checkout
         version = None
-        parse_result = urlparse(git_url)
 
         # Prepend 'ssh://' and replace the first ':' with '/' if git_url
         # looks like a scp-like URL, e.g. git@github.com:user/repo.git.
@@ -2842,7 +2841,7 @@ class Manager(object):
                     try:
                         os.unlink(old)
                         LOG.debug('removed link %s', old)
-                    except:
+                    except Exception:
                         LOG.warn('failed to remove link %s', old)
 
 

--- a/zeekpkg/package.py
+++ b/zeekpkg/package.py
@@ -6,6 +6,8 @@ the properties and status of Zeek packages.
 import os
 import re
 
+from functools import total_ordering
+
 from .uservar import UserVar
 from ._util import find_sentence_end
 
@@ -134,6 +136,7 @@ def dependencies(metadata_dict, field='depends'):
     return rval
 
 
+@total_ordering
 class InstalledPackage(object):
     """An installed package and its current status.
 
@@ -142,10 +145,15 @@ class InstalledPackage(object):
 
         status (:class:`PackageStatus`): the status of the installed package
     """
-
     def __init__(self, package, status):
         self.package = package
         self.status = status
+
+    def __hash__(self):
+        return hash(str(self.package))
+
+    def __eq__(self, other):
+        return str(self.package) == str(other.package)
 
     def __lt__(self, other):
         return str(self.package) < str(other.package)
@@ -287,6 +295,7 @@ class PackageInfo(object):
         return self.default_branch
 
 
+@total_ordering
 class Package(object):
     """A Zeek package.
 
@@ -317,7 +326,6 @@ class Package(object):
             aggregation of the source's :file:`aggregate.meta` file (it may not
             be accurate/up-to-date).
     """
-
     def __init__(self, git_url, source='', directory='', metadata=None,
                  name=None, canonical=False):
         self.git_url = git_url
@@ -341,6 +349,12 @@ class Package(object):
 
     def __repr__(self):
         return self.git_url
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        return str(self) == str(other)
 
     def __lt__(self, other):
         return str(self) < str(other)

--- a/zeekpkg/template.py
+++ b/zeekpkg/template.py
@@ -361,7 +361,7 @@ class Template():
         try:
             if self._repo:
                 return self._repo.head.ref.commit.hexsha
-        except:
+        except Exception:
             pass
 
         return None

--- a/zkg
+++ b/zkg
@@ -20,7 +20,7 @@ from collections import OrderedDict
 
 try:
     import git
-    import semantic_version as semver # lgtm[py/unused-import]
+    import semantic_version  # noqa  # pylint: disable=unused-import
 except ImportError as error:
     print("error: zkg failed to import one or more dependencies:\n"
           "\n"
@@ -1417,13 +1417,8 @@ def cmd_upgrade(manager, args, config, configfile):
                                            default_to_yes=False):
                     return
 
-    join_timeout = 0.01
-    tick_interval = 1
-
     for info, version, _ in reversed(new_pkgs):
         name = info.package.qualified_name()
-        time_accumulator = 0
-        tick_count = 0
         worker = InstallWorker(manager, name, version)
         worker.start()
         worker.wait('Installing "{}"'.format(name))


### PR DESCRIPTION
These changes silence the [remaining warnings](https://github.com/zeek/package-manager/security/code-scanning) triggered by CodeQL.