### PR TITLE
Fix Github edit links in top-right of HTML pages

### DIFF
--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -5,7 +5,7 @@
 {% if pagename != "search" %}
   {% if display_github %}
     {% if github_version == "master" %}
-      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
     {% endif %}
   {% elif show_source and has_source and sourcename %}
     <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>

--- a/testing/packages/rot13/CMakeLists.txt
+++ b/testing/packages/rot13/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(Plugin)
 


### PR DESCRIPTION
These links 404'd because they omitted the file suffix, and they didn't really link to anything editable, just the raw file.

---

In this case, "suffix" was used which is set by the readthedocs theme in older versions [1]. Seem good to replace with page_source_suffix.

Relates to zeek/zeek-docs#222

[1] https://github.com/readthedocs/sphinx_rtd_theme/pull/1104