### PR TITLE
Place .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: ./requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,14 +119,7 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-if not on_rtd:
-    # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
     "collapse_navigation": False,

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -13,7 +13,9 @@ that any developer can request their Zeek package be included. See the
 ``README`` file of that repository for information regarding the package
 submission process.
 
-:note: It's left up to users to decide for themselves via code review,
+.. note::
+
+       It's left up to users to decide for themselves via code review,
        GitHub comments/stars, or other metrics whether any given package
        is trustworthy as there is no implied guarantees that it's secure
        just because it's been accepted into the default package source.


### PR DESCRIPTION
This is now required for readthedocs projects.

https://blog.readthedocs.com/migrate-configuration-v2/

> Monday, September 25, 2023: Fully remove support for building documentation without configuration file v2.


Link to test build:

https://docs.zeek.org/projects/package-manager/en/topic-awelzel-readthedocs-yaml/