### PR TITLE
manager: Support __zeek_plugin__ magic file

### DIFF
--- a/testing/tests/plugin
+++ b/testing/tests/plugin
@@ -3,21 +3,21 @@
 # @TEST-EXEC: bash %INPUT
 # @TEST-EXEC: zkg install rot13
 
-# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__
+# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__ || test -f plugins/packages/rot13/__zeek_plugin__
 # @TEST-EXEC: btest-diff scripts/packages/rot13/__load__.zeek
 
 # Unloading the package should also disable the plugin, which we
 # detect via the renamed __bro_plugin__ magic file.
 # @TEST-EXEC: zkg unload rot13
 
-# @TEST-EXEC: test ! -f plugins/packages/rot13/__bro_plugin__
-# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__.disabled
+# @TEST-EXEC: test ! -f plugins/packages/rot13/__bro_plugin__ && test ! -f plugins/packages/rot13/__zeek_plugin__
+# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__.disabled || test -f plugins/packages/rot13/__zeek_plugin__.disabled
 
 # (Re-)loading the package should also (re-)enable the plugin.
 # @TEST-EXEC: zkg load rot13
 
-# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__
-# @TEST-EXEC: test ! -f plugins/packages/rot13/__bro_plugin__.disabled
+# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__ || test -f plugins/packages/rot13/__zeek_plugin__
+# @TEST-EXEC: test ! -f plugins/packages/rot13/__bro_plugin__.disabled && test ! -f plugins/packages/rot13/__zeek_plugin__.disabled
 
 echo "$(pwd)/packages/rot13" >> sources/one/bob/zkg.index
 cd sources/one

--- a/testing/tests/plugin_tarfile
+++ b/testing/tests/plugin_tarfile
@@ -3,7 +3,7 @@
 # @TEST-EXEC: bash %INPUT
 # @TEST-EXEC: zkg install rot13
 
-# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__
+# @TEST-EXEC: test -f plugins/packages/rot13/__bro_plugin__ || test -f plugins/packages/rot13/__zeek_plugin__
 # @TEST-EXEC: btest-diff scripts/packages/rot13/__load__.zeek
 
 cd packages/rot13

--- a/zeekpkg/package.py
+++ b/zeekpkg/package.py
@@ -24,8 +24,10 @@ TRACKING_METHOD_BUILTIN = "builtin"
 BUILTIN_SOURCE = "zeek-builtin"
 BUILTIN_SCHEME = "zeek-builtin://"
 
-PLUGIN_MAGIC_FILE = "__bro_plugin__"
-PLUGIN_MAGIC_FILE_DISABLED = "__bro_plugin__.disabled"
+PLUGIN_MAGIC_FILE = "__zeek_plugin__"
+PLUGIN_MAGIC_FILE_DISABLED = "__zeek_plugin__.disabled"
+LEGACY_PLUGIN_MAGIC_FILE = "__bro_plugin__"
+LEGACY_PLUGIN_MAGIC_FILE_DISABLED = "__bro_plugin__.disabled"
 
 
 def name_from_path(path):


### PR DESCRIPTION
Zeek 6.1 switched from __bro_plugin__ to __zeek_plugin__. Modify _write_plugin_magic() to handle the new and the old file.

Closes #171