### PR TITLE
Standardize on ruff for python formatting/linting via pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,16 @@ repos:
     exclude: testing/baselines
   - id: check-yaml
   - id: check-added-large-files
-- repo: https://github.com/psf/black
-  rev: 23.1a1
-  hooks:
-  - id: black
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.15.1
   hooks:
   - id: pyupgrade
     args: ["--py37-plus"]
-- repo: https://github.com/pycqa/flake8
-  rev: 5.0.4  # 6.0.0 requires Python 3.8
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.3.0
   hooks:
-  - id: flake8
+    - id: ruff
+      args: [--fix]
+    - id: ruff-format
 
 exclude: doc/ext/sphinxarg

--- a/zeekpkg/__init__.py
+++ b/zeekpkg/__init__.py
@@ -10,12 +10,12 @@ may be added in order to help log/debug applications.
 import logging
 
 __version__ = "3.0.1-6"
-__all__ = ["manager", "package", "source", "template", "uservar"]
+__all__ = ["manager", "package", "source", "template", "uservar"]  # noqa: F405
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 
-from .manager import *
-from .package import *
-from .source import *
-from .uservar import *
+from .manager import *  # noqa: E402, F403
+from .package import *  # noqa: E402, F403
+from .source import *  # noqa: E402, F403
+from .uservar import *  # noqa: E402, F403

--- a/zeekpkg/template.py
+++ b/zeekpkg/template.py
@@ -1,6 +1,7 @@
 """
 A module for instantiating different types of Zeek packages.
 """
+
 import abc
 import configparser
 import re
@@ -797,9 +798,7 @@ class Package(_Content):
             """Initial commit.
 
 zkg {} created this package from template "{}"
-using {}{}.""".format(
-                __version__, tmpl.name(), ver_info, features_info
-            )
+using {}{}.""".format(__version__, tmpl.name(), ver_info, features_info)
         )
 
 

--- a/zeekpkg/uservar.py
+++ b/zeekpkg/uservar.py
@@ -3,6 +3,7 @@ A module for zkg's notion of "user variables": named values required
 by packages that the user can provide in a variety of ways, including
 responses to zkg's input prompting.
 """
+
 import os
 import re
 import readline

--- a/zkg
+++ b/zkg
@@ -85,26 +85,26 @@ ZKG_DEFAULT_SOURCE = "https://github.com/zeek/packages"
 # The default package template
 ZKG_DEFAULT_TEMPLATE = "https://github.com/zeek/package-template"
 
-from zeekpkg._util import (
+from zeekpkg._util import (  # noqa: E402
     delete_path,
     make_dir,
     find_program,
     read_zeek_config_line,
     std_encoding,
 )
-from zeekpkg.package import (
+from zeekpkg.package import (  # noqa: E402
     BUILTIN_SCHEME,
     TRACKING_METHOD_VERSION,
 )
-from zeekpkg.template import (
+from zeekpkg.template import (  # noqa: E402
     LoadError,
     Template,
 )
-from zeekpkg.uservar import (
+from zeekpkg.uservar import (  # noqa: E402
     UserVar,
 )
 
-import zeekpkg
+import zeekpkg  # noqa: E402
 
 
 def confirmation_prompt(prompt, default_to_yes=True):


### PR DESCRIPTION
This is part of a minor effort to standardize all of our python pre-commits on the same tooling, in this case [ruff](https://github.com/astral-sh/ruff). It adds one minor formatting fix and fixes a few findings from the linter (some by just suppressing them).