### PR TITLE
Make requirements.txt match pyproject file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # NOTE: Dependencies should go into `pyproject.toml`. We keep this file to e.g., support RTD.
 
 # Requirements for general zkg usage
-GitPython>3.1.43
-semantic_version>2.10.0
+GitPython>=3.1.43
+semantic_version>=2.10.0
 # Requirements for development (e.g. building docs)
 btest>=1.1
 Sphinx>=7.2.6


### PR DESCRIPTION
Notably, the two versions listed here are the current releases. The current setting causes RTD to fail since it can't find versions newer than those.