### PR TITLE
Pull in `btest` when installing package manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,12 @@ classifiers = [
 dependencies = [
     "GitPython>=3.1.43",
     "semantic_version>=2.10.0",
+    # Technically not a zkg dependency, but typically expected by users to be present.
+    "btest>=1.1",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "btest>=1.1",
     "Sphinx>=7.2.6",
     "sphinx_rtd_theme>=2.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 # Requirements for general zkg usage
 GitPython>=3.1.43
 semantic_version>=2.10.0
-# Requirements for development (e.g. building docs)
+# Technically not a zkg dependency, but typically expected by users to be present.
 btest>=1.1
+# Requirements for development (e.g. building docs)
 Sphinx>=7.2.6
 sphinx_rtd_theme>=2.0.0


### PR DESCRIPTION
This reverts a24124d2f298b306e47d43a8aa0361f98ede9a04 where we moved `btest` into a dev dependency which would not be installed by default. While this would have been unobservable for users getting their `zkg` via Zeek (which also provides `btest`), or who install `zkg` via `pipx` (which even previously would never have linked the pulled in `btest` into the prefix), it might break users installing via `pip` into a random prefix.