### PR TITLE
Fix UnicodeEncodeError in `zkg create` with non-ASCII characters in user vars

### DIFF
--- a/testing/baselines/tests.template-create/output
+++ b/testing/baselines/tests.template-create/output
@@ -8,3 +8,4 @@
 <...>/out3 (installed: master) - TODO: A more detailed description of test3.
 error: could not determine value of user variable "name", provide via environment or --user-var
 error: the following features are unknown: "doesntexist". Template "foo" offers "readme".
+"foo" will use value of "name" (the name of the package, e.g. "FooBar") from command line: 你こ안مγПनสXש😊©GBCDČM

--- a/testing/tests/template-create
+++ b/testing/tests/template-create
@@ -36,4 +36,8 @@
 # Request an unknown feature. This should fail.
 # @TEST-EXEC-FAIL: zkg create --packagedir out5 --template $TEMPLATES/foo --feature doesntexist >>output 2>&1
 
+# Provide non-ASCII characters variable via --user-var and ensure resulting package installs
+# @TEST-EXEC: zkg create --packagedir out6 --template $TEMPLATES/foo --user-var name=你こ안مγПनสXש😊©GBCDČM >>output
+# @TEST-EXEC: zkg install ./out6
+
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff output

--- a/zeekpkg/template.py
+++ b/zeekpkg/template.py
@@ -687,8 +687,8 @@ class _Content(metaclass=abc.ABCMeta):
         for name, val in tmpl.params().items():
             pat = "@" + name + "@"
             if not isinstance(content, str):
-                pat = bytes(pat, "ascii")
-                val = bytes(val, "ascii")
+                pat = bytes(pat, "utf-8")
+                val = bytes(val, "utf-8")
             content = re.sub(pat, val, content, flags=re.IGNORECASE)
 
         return content


### PR DESCRIPTION
Closes #193 