### PR TITLE
Enable lints around return statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.2
+  rev: v0.11.7
   hooks:
     - id: ruff
       args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,4 @@ script-files = ["zkg"]
 universal = true
 
 [tool.ruff.lint]
-select = ["A", "B", "C4", "COM", "F", "I", "ISC", "N", "RUF", "UP"]
+select = ["A", "B", "C4", "COM", "F", "I", "ISC", "N", "RUF", "RET", "UP"]

--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -25,7 +25,8 @@ def make_dir(path):
     except OSError as exception:
         if exception.errno != errno.EEXIST:
             raise
-        elif os.path.isfile(path):
+
+        if os.path.isfile(path):
             raise
 
 

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -1318,15 +1318,17 @@ class Manager:
         if ipkg.status.tracking_method == TRACKING_METHOD_VERSION:
             version_tags = git_version_tags(clone)
             return self._install(ipkg.package, version_tags[-1])
-        elif ipkg.status.tracking_method == TRACKING_METHOD_BRANCH:
+
+        if ipkg.status.tracking_method == TRACKING_METHOD_BRANCH:
             git_pull(clone)
             return self._install(ipkg.package, ipkg.status.current_version)
-        elif ipkg.status.tracking_method == TRACKING_METHOD_COMMIT:
+
+        if ipkg.status.tracking_method == TRACKING_METHOD_COMMIT:
             # The above check for whether the installed package is outdated
             # also should have already caught this situation.
             return "package is not outdated"
-        else:
-            raise NotImplementedError
+
+        raise NotImplementedError
 
     def remove(self, pkg_path):
         """Remove an installed package.
@@ -1690,26 +1692,26 @@ class Manager:
                     continue
 
                 # check if all dependers are unloaded
-                elif _has_all_dependers_unloaded(item, dep_packages):
+                if _has_all_dependers_unloaded(item, dep_packages):
                     self.unload(item)
                     errors.append((item, ""))
                     continue
 
                 # package is in use
-                else:
-                    dep_packages = self.list_depender_pkgs(pkg_name)
-                    dep_listing = ""
+                dep_packages = self.list_depender_pkgs(pkg_name)
+                dep_listing = ""
 
-                    for _name in dep_packages:
-                        dep_listing += f'"{_name}", '
+                for _name in dep_packages:
+                    dep_listing += f'"{_name}", '
 
-                    errors.append(
-                        (
-                            item,
-                            f"Package is in use by other packages --- {dep_listing[:-2]}.",
-                        ),
-                    )
-                    return errors
+                errors.append(
+                    (
+                        item,
+                        f"Package is in use by other packages --- {dep_listing[:-2]}.",
+                    ),
+                )
+
+                return errors
 
         return errors
 
@@ -1850,9 +1852,9 @@ class Manager:
             clonepath = os.path.join(self.package_clonedir, pkg_name)
             clone = git.Repo(clonepath)
             return _info_from_clone(clone, ipkg.package, status, status.current_version)
-        else:
-            status = None
-            matches = self.match_source_packages(pkg_path)
+
+        status = None
+        matches = self.match_source_packages(pkg_path)
 
         if not matches:
             package = Package(git_url=pkg_path)
@@ -2841,12 +2843,12 @@ class Manager:
         else:
             if "script_dir" in metadata:
                 return f"no __load__.zeek file found in package's 'script_dir' : {pkg_script_dir}"
-            else:
-                LOG.warning(
-                    'installing "%s": no __load__.zeek in implicit'
-                    " script_dir, skipped installing scripts",
-                    package,
-                )
+
+            LOG.warning(
+                'installing "%s": no __load__.zeek in implicit'
+                " script_dir, skipped installing scripts",
+                package,
+            )
 
         pkg_plugin_dir = metadata.get("plugin_dir", "build")
         plugin_dir_src = os.path.join(clone.working_dir, pkg_plugin_dir)
@@ -2927,13 +2929,15 @@ class Manager:
                 clonepath = os.path.join(self.package_clonedir, conflict.name)
                 _clone_package(conflict, clonepath, version)
                 return self._install(conflict, version)
-            else:
-                LOG.info(
-                    'installing "%s": matched already installed package: %s',
-                    pkg_path,
-                    conflict,
-                )
-                return f'package with name "{conflict.name}" ({conflict}) is already installed'
+
+            LOG.info(
+                'installing "%s": matched already installed package: %s',
+                pkg_path,
+                conflict,
+            )
+            return (
+                f'package with name "{conflict.name}" ({conflict}) is already installed'
+            )
 
         matches = self.match_source_packages(pkg_path)
 
@@ -3201,12 +3205,14 @@ def _is_branch_outdated(clone, branch):
 def _is_clone_outdated(clone, ref_name, tracking_method):
     if tracking_method == TRACKING_METHOD_VERSION:
         return _is_version_outdated(clone, ref_name)
-    elif tracking_method == TRACKING_METHOD_BRANCH:
+
+    if tracking_method == TRACKING_METHOD_BRANCH:
         return _is_branch_outdated(clone, ref_name)
-    elif tracking_method == TRACKING_METHOD_COMMIT:
+
+    if tracking_method == TRACKING_METHOD_COMMIT:
         return False
-    else:
-        raise NotImplementedError
+
+    raise NotImplementedError
 
 
 def _is_commit_hash(clone, text):
@@ -3305,8 +3311,7 @@ def _clone_package(package, clonepath, version):
 
 
 def _get_package_metadata(parser):
-    metadata = {item[0]: item[1] for item in parser.items("package")}
-    return metadata
+    return {item[0]: item[1] for item in parser.items("package")}
 
 
 def _pick_metadata_file(directory):

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -921,8 +921,7 @@ class Manager:
                 # Their config file is outside script/plugin install dirs,
                 # so no way user has it even installed, much less modified.
                 LOG.warning(
-                    "package '%s' config file '%s' not within"
-                    " plugin_dir or script_dir",
+                    "package '%s' config file '%s' not within plugin_dir or script_dir",
                     pkg_name,
                     config_file,
                 )

--- a/zeekpkg/template.py
+++ b/zeekpkg/template.py
@@ -309,7 +309,7 @@ class Template:
         Returns:
             zeekpkg.template.Package instance
         """
-        return None
+        pass
 
     def features(self):
         """Provides any additional features templates supported.
@@ -483,7 +483,7 @@ class _Content(metaclass=abc.ABCMeta):
         Returns:
             str: relative path to the content directory
         """
-        return None
+        pass
 
     def needed_user_vars(self):
         """Returns a list of user vars names required by this content.

--- a/zkg
+++ b/zkg
@@ -118,9 +118,9 @@ def confirmation_prompt(prompt, default_to_yes=True):
     if not choice:
         if default_to_yes:
             return True
-        else:
-            print("Abort.")
-            return False
+
+        print("Abort.")
+        return False
 
     if choice in yes:
         return True
@@ -324,8 +324,7 @@ def active_git_branch(path):
     if not rval:
         return None
 
-    rval = str(rval)
-    return rval
+    return str(rval)
 
 
 def is_local_git_repo_url(git_url) -> bool:

--- a/zkg
+++ b/zkg
@@ -1244,8 +1244,7 @@ def cmd_refresh(manager, args, config, configfile):
 
     if args.fail_on_aggregate_problems and not args.aggregate:
         print_error(
-            "warning: --fail-on-aggregate-problems without --aggregate"
-            " has no effect.",
+            "warning: --fail-on-aggregate-problems without --aggregate has no effect.",
         )
 
     had_failure = False
@@ -2431,8 +2430,7 @@ def argparser():
             type=int,
             default=None,
             metavar="SPACES",
-            help="Optional number of spaces to indent for pretty-printed"
-            " JSON output.",
+            help="Optional number of spaces to indent for pretty-printed JSON output.",
         )
 
     top_parser = top_level_parser()


### PR DESCRIPTION
This enables a class of return-related lints[^1] around return
statements. I mainly came here for redundant returns after `else`[^2],
but they all seemed useful. In general this seems to reduce nesting, and
also make overall flow clearer.

[^1]: https://docs.astral.sh/ruff/rules/#flake8-return-ret
[^2]: https://docs.astral.sh/ruff/rules/superfluous-else-return/