### PR TITLE
Do not require that user vars are non-empty

### DIFF
--- a/testing/templates/foo/__init__.py
+++ b/testing/templates/foo/__init__.py
@@ -44,7 +44,7 @@ class Template(zeekpkg.template.Template):
     def apply_user_vars(self, user_vars: list[zeekpkg.uservar.UserVar]) -> None:
         for uvar in user_vars:
             val = uvar.val()
-            assert val
+            assert val is not None
 
             if uvar.name() == "name":
                 self.define_param("name", val)

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -3259,7 +3259,7 @@ class Manager:
 
             if uvar.name() not in substitutions:
                 val = uvar.val()
-                assert val
+                assert val is not None
                 substitutions[uvar.name()] = val
 
         # Now apply the substitutions via a new config parser:

--- a/zeekpkg/uservar.py
+++ b/zeekpkg/uservar.py
@@ -122,7 +122,7 @@ class UserVar:
                 f'"{name}" will use value of "{self._name}" ({self._desc}) from {source}: {val}',
             )
             self._val = val
-            assert val
+            assert val is not None
             return val
 
         if val is None:


### PR DESCRIPTION
When typing this code in #209 we introduced checks that variables of types like `str | None` were set. In making that we accidentially used a narrower requirement that user vars were not only set, but also not empty. This is because

    assert val

for a `val: str` means "is set, and its value is truthy (i.e., the `str` is not empty).

Since we still catch empty users vars elsewhere this still had the same effect, but now potentially exposed users to a naked `AssertionError` instead of an error message.

With this patch we just require that user variables are set.