### PR TITLE
Fix path handling bug in `safe_tarfile_extractall`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: trailing-whitespace
     exclude: testing/baselines
@@ -11,14 +11,14 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.9
+  rev: a27a2e47c7751b639d2b5badf0ef6ff11fee893f  # frozen: v0.15.4
   hooks:
     - id: ruff
       args: [--fix]
     - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.17.1
+  rev: a66e98df7b4aeeb3724184b332785976d062b92e  # frozen: v1.19.1
   hooks:
   - id: mypy
     args: [--strict]

--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -100,7 +100,7 @@ def safe_tarfile_extractall(tfile: str, destdir: str) -> None:
     def is_within_directory(directory: str, target: str) -> bool:
         abs_directory = os.path.abspath(directory)
         abs_target = os.path.abspath(target)
-        prefix = os.path.commonprefix([abs_directory, abs_target])
+        prefix = os.path.commonpath([abs_directory, abs_target])
         return prefix == abs_directory
 
     with tarfile.open(tfile) as tar:

--- a/zeekpkg/_util.py
+++ b/zeekpkg/_util.py
@@ -13,7 +13,7 @@ import subprocess
 import tarfile
 import types
 from collections.abc import Callable, Iterable
-from typing import IO, TextIO, cast
+from typing import IO, TextIO
 
 import git
 import semantic_version as semver
@@ -220,13 +220,13 @@ def git_default_branch(repo: git.Repo) -> str:
     if remote:
         # Technically possible that remote has no HEAD, so guard against that.
         try:
-            ref = cast(git.Reference, repo.head.ref)
+            ref_name = repo.head.ref.name
             remote_prefix = "origin/"
 
-            if ref.name.startswith(remote_prefix):
-                return ref.name[len(remote_prefix) :]
+            if ref_name.startswith(remote_prefix):
+                return ref_name[len(remote_prefix) :]
 
-            return ref.name
+            return ref_name
         except Exception:
             ...
 
@@ -239,9 +239,8 @@ def git_default_branch(repo: git.Repo) -> str:
         return "master"
 
     try:
-        # See if there's a branch currently checked out
-        ref = cast(git.Reference, repo.head.ref)
-        return ref.name
+        # This throws if no branch is currently checked out.
+        return repo.head.ref.name
     except TypeError:
         # No branch checked out, return commit hash
         return repo.head.object.hexsha


### PR DESCRIPTION
The helper function `is_within_directory` could return false positives which might have lead to incorrect tarball extraction. This was triggered by https://sethmlarson.dev/deprecate-confusing-apis-like-os-path-commonprefix; we run into the same issue as mentioned there.