### PR TITLE
Fix quickstart grammar typo

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -249,7 +249,7 @@ file which contains a snapshot of all currently installed packages:
 Then transfer :file:`zeek-packages.bundle` to the Zeek deployment
 management host.  For Zeek clusters using ZeekControl_, this will
 be the system acting as the "manager" node.  Then on that system
-(assuming it already as :program:`zkg` installed and configured):
+(assuming it already has :program:`zkg` installed and configured):
 
 .. code-block:: console
 


### PR DESCRIPTION
## Summary

- Fix a grammar typo in the package bundle quickstart text.

## Validation

- `git diff --check`
- `/tmp/oc-pr-zeek-venv/bin/sphinx-build -b dummy doc doc/_build/dummy`

Note: I also tried the same Sphinx dummy build with `-W`; it hit two existing duplicate object description warnings outside this wording change.
