### PR TITLE
docs: fix typos

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -226,7 +226,7 @@ Offline Usage
 ~~~~~~~~~~~~~
 
 It's common to have limited network/internet access on the systems where
-Zeek is deployed.  To accomodate those scenarios, :program:`zkg` can
+Zeek is deployed.  To accommodate those scenarios, :program:`zkg` can
 be used as normally on a system that *does* have network access to
 create bundles of its package installation environment. Those bundles
 can then be transferred to the deployment systems via whatever means are

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -53,7 +53,7 @@ Adding Packages
 
 Adding packages is as simple as adding new :ref:`Package Index Files
 <package-index-file>` or extending existing ones with new URLs and then
-commiting/pushing those changes to the package source git repository.
+committing/pushing those changes to the package source git repository.
 
 :ref:`zkg <zkg>` will see new packages listed the next time it uses
 the :ref:`refresh command <refresh-command>`.

--- a/zkg
+++ b/zkg
@@ -2871,7 +2871,7 @@ def argparser() -> argparse.ArgumentParser:
     sub_parser = command_parser.add_parser(
         "upgrade",
         help="Upgrade installed packages to latest versions.",
-        description="Uprades the specified package(s) to latest available"
+        description="Upgrades the specified package(s) to latest available"
         " version.  If no specific packages are specified, then all installed"
         " packages that are outdated and not pinned are upgraded.  For packages"
         " that are installed with ``--version`` using a git branch name, the"


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check