### PR TITLE
Install actually working version of the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
       - "types-setuptools>=80.9.0.20250809"
       - "pytest>=9.0.3"
     exclude: "doc/.*"
+
+- repo: https://github.com/cheshirekow/cmake-format-precommit
+  rev: e2c2116d86a80e72e7146a06e68b7c228afc6319  # frozen: v0.6.13
+  hooks:
+  - id: cmake-format
+  - id: cmake-lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ configure_file(zkg.sh.in "${CMAKE_CURRENT_BINARY_DIR}/zkg" @ONLY)
 install(FILES "${ZKG_PYZ}" DESTINATION "share/${PROJECT_NAME}/lib")
 install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/zkg" DESTINATION bin)
 
-if (NOT ZEEK_MAN_INSTALL_PATH)
-    set(ZEEK_MAN_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/share/man)
-endif ()
+if(NOT ZEEK_MAN_INSTALL_PATH)
+  set(ZEEK_MAN_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/share/man)
+endif()
 
 install(FILES doc/man/zkg.1 DESTINATION ${ZEEK_MAN_INSTALL_PATH}/man1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,37 +1,48 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(zkg)
 
-set(ZEEK_BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
-set(orig_file ${CMAKE_CURRENT_SOURCE_DIR}/zkg)
-set(configed_file ${CMAKE_CURRENT_BINARY_DIR}/zkg)
-configure_file(${orig_file} ${configed_file} @ONLY)
+find_package(
+  Python3
+  COMPONENTS Interpreter
+  REQUIRED)
 
-# Install zkg
-install(DIRECTORY DESTINATION bin)
-install(PROGRAMS ${configed_file} DESTINATION bin)
+# Set up a virtual env to install `shiv` which we use for bundling zkg into a
+# Python interpreter-loadable pyz file.
+set(VENV "${CMAKE_CURRENT_BINARY_DIR}/_venv")
+set(SHIV "${VENV}/bin/shiv")
+add_custom_command(
+  OUTPUT "${SHIV}"
+  COMMENT "Preparing shiv"
+  COMMAND ${Python3_EXECUTABLE} -m venv "${VENV}"
+  COMMAND "${VENV}/bin/pip" install shiv==1.0.8
+  VERBATIM)
+add_custom_target(
+  shiv_install ALL
+  COMMENT "shiv install"
+  DEPENDS "${SHIV}")
 
-if ( NOT PY_MOD_INSTALL_DIR )
-    # This is not a Zeek-bundled install. Default to "home"-style install.
-    set(PY_MOD_INSTALL_DIR lib/python)
-endif ()
+set(ZKG_PYZ "${CMAKE_CURRENT_BINARY_DIR}/zkg.pyz")
+add_custom_command(
+  OUTPUT "${ZKG_PYZ}"
+  COMMENT "Bundling zkg"
+  COMMAND "${SHIV}" -c zkg -o "${ZKG_PYZ}" zkg
+  # TODO: Ideally this would also depend on anything in `zeekpkg/` changing.
+  DEPENDS shiv_install pyproject.toml zkg
+  VERBATIM)
+add_custom_target(
+  zkg_pyz ALL
+  COMMENT "bundled zkg"
+  DEPENDS "${ZKG_PYZ}")
 
-# Install the Python module tree
-install(DIRECTORY DESTINATION ${PY_MOD_INSTALL_DIR})
-install(DIRECTORY zeekpkg DESTINATION ${PY_MOD_INSTALL_DIR})
+# Bake discovered Python interpreter into wrapper invoking created zkg.pyz.
+configure_file(zkg.sh.in "${CMAKE_CURRENT_BINARY_DIR}/zkg")
 
-if ( NOT ZEEK_MAN_INSTALL_PATH )
+# Install both the bundle as well as the generated wrapper.
+install(FILES "${ZKG_PYZ}" DESTINATION "share/${PROJECT_NAME}/lib")
+install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/zkg" DESTINATION bin)
+
+if (NOT ZEEK_MAN_INSTALL_PATH)
     set(ZEEK_MAN_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/share/man)
 endif ()
 
 install(FILES doc/man/zkg.1 DESTINATION ${ZEEK_MAN_INSTALL_PATH}/man1)
-
-message(
-    "\n=====================|  ZKG Build Summary  |===================="
-    "\n"
-    "\nInstall prefix:      ${CMAKE_INSTALL_PREFIX}"
-    "\nPython module path:  ${PY_MOD_INSTALL_DIR}"
-    "\nConfig path:         ${ZEEK_ZKG_CONFIG_DIR}"
-    "\nState path:          ${ZEEK_ZKG_STATE_DIR}"
-    "\n"
-    "\n================================================================\n"
-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ add_custom_target(
   DEPENDS "${ZKG_PYZ}")
 
 # Bake discovered Python interpreter into wrapper invoking created zkg.pyz.
-configure_file(zkg.sh.in "${CMAKE_CURRENT_BINARY_DIR}/zkg")
+configure_file(zkg.sh.in "${CMAKE_CURRENT_BINARY_DIR}/zkg" @ONLY)
 
 # Install both the bundle as well as the generated wrapper.
 install(FILES "${ZKG_PYZ}" DESTINATION "share/${PROJECT_NAME}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-project(zkg)
+project(zkg NONE)
 
 find_package(
   Python3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(zkg NONE)
 
 find_package(

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -26,14 +26,6 @@ Installation
   directions to build and install Zeek from source are here:
   https://docs.zeek.org/en/current/install/install.html
 
-  Note that this method does require independent installation of
-  :program:`zkg`'s dependencies, which is usually easiest to do via
-  :program:`pip3`:
-
-  .. code-block:: console
-
-    $ pip3 install gitpython semantic-version
-
 * To install the latest release of :program:`zkg` on PyPI_:
 
   .. code-block:: console

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -7,11 +7,7 @@ Quickstart Guide
 Dependencies
 ------------
 
-* Python 3.6+
 * git: https://git-scm.com
-* GitPython: https://pypi.python.org/pypi/GitPython
-* semantic_version: https://pypi.python.org/pypi/semantic_version
-* btest: https://pypi.python.org/pypi/btest
 
 Note that following the :program:`zkg` `Installation`_ process via
 :program:`pip3` will automatically install its dependencies for you.

--- a/testing/packages/rot13/CMakeLists.txt
+++ b/testing/packages/rot13/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.15)
 
 project(Plugin)

--- a/zkg
+++ b/zkg
@@ -46,47 +46,6 @@ try:
 except ImportError:
     pass
 
-# For Zeek-bundled installation, prepend the Python path of the Zeek
-# installation. This ensures we find the matching zeekpkg module
-# first, avoiding potential conflicts with installations elsewhere on
-# the system.
-ZEEK_PYTHON_DIR: str | None = "@PY_MOD_INSTALL_DIR@"
-assert isinstance(ZEEK_PYTHON_DIR, str)
-if os.path.isdir(ZEEK_PYTHON_DIR):
-    sys.path.insert(0, os.path.abspath(ZEEK_PYTHON_DIR))
-else:
-    ZEEK_PYTHON_DIR = None
-
-# Similarly, make Zeek's binary installation path available by
-# default. This helps package installations succeed that require
-# e.g. zeek-config for their build process.
-ZEEK_BIN_DIR: str | None = "@ZEEK_BIN_DIR@"
-assert isinstance(ZEEK_BIN_DIR, str)
-if os.path.isdir(ZEEK_BIN_DIR):
-    try:
-        if ZEEK_BIN_DIR not in os.environ["PATH"].split(os.pathsep):
-            os.environ["PATH"] = ZEEK_BIN_DIR + os.pathsep + os.environ["PATH"]
-    except KeyError:
-        os.environ["PATH"] = ZEEK_BIN_DIR
-else:
-    ZEEK_BIN_DIR = None
-
-# Also when bundling with Zeek, use directories in the install tree
-# for storing the zkg configuration and its variable state. Support
-# for overrides via environment variables simplifies testing.
-ZEEK_ZKG_CONFIG_DIR: str | None = (
-    os.getenv("ZEEK_ZKG_CONFIG_DIR") or "@ZEEK_ZKG_CONFIG_DIR@"
-)
-assert isinstance(ZEEK_ZKG_CONFIG_DIR, str)
-if not os.path.isdir(ZEEK_ZKG_CONFIG_DIR):
-    ZEEK_ZKG_CONFIG_DIR = None
-
-ZEEK_ZKG_STATE_DIR: str | None = (
-    os.getenv("ZEEK_ZKG_STATE_DIR") or "@ZEEK_ZKG_STATE_DIR@"
-)
-assert isinstance(ZEEK_ZKG_STATE_DIR, str)
-if not os.path.isdir(ZEEK_ZKG_STATE_DIR):
-    ZEEK_ZKG_STATE_DIR = None
 
 # The default package source we fall back to as needed
 ZKG_DEFAULT_SOURCE = "https://github.com/zeek/packages"
@@ -237,11 +196,11 @@ def home_config_dir() -> str:
 
 
 def default_config_dir() -> str:
-    return ZEEK_ZKG_CONFIG_DIR or home_config_dir()
+    return os.getenv("ZEEK_ZKG_CONFIG_DIR") or home_config_dir()
 
 
 def default_state_dir() -> str:
-    return ZEEK_ZKG_STATE_DIR or home_config_dir()
+    return os.getenv("ZEEK_ZKG_STATE_DIR") or home_config_dir()
 
 
 def create_config(

--- a/zkg.sh.in
+++ b/zkg.sh.in
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+WRAPPER_DIR="$(dirname "$0")"
+ZKG_PYZ="${WRAPPER_DIR}/../share/zkg/lib/zkg.pyz"
+
+# Location where shiv will unpack the pyz. We overwrite the default value of
+# `~/.shiv` to make it clear that this is ephemeral information which can be
+# garbage-collected.
+SHIV_ROOT=$HOME/.cache/zkg
+export SHIV_ROOT
+
+exec "@Python3_EXECUTABLE@" "${ZKG_PYZ}" "$@"

--- a/zkg.sh.in
+++ b/zkg.sh.in
@@ -2,6 +2,21 @@
 
 set -eu
 
+ZEEK_BIN_DIR="@ZEEK_BIN_DIR@"
+if [ -d "$ZEEK_BIN_DIR" ]; then
+  export PATH="$ZEEK_BIN_DIR:$PATH"
+fi
+
+ZEEK_ZKG_CONFIG_DIR=${ZEEK_ZKG_CONFIG_DIR:-@ZEEK_ZKG_CONFIG_DIR@}
+if [ -d "$ZEEK_ZKG_CONFIG_DIR" ]; then
+  export ZEEK_ZKG_CONFIG_DIR
+fi
+
+ZEEK_ZKG_STATE_DIR=${ZEEK_ZKG_STATE_DIR:-@ZEEK_ZKG_STATE_DIR@}
+if [ -d "$ZEEK_ZKG_STATE_DIR" ]; then
+  export ZEEK_ZKG_STATE_DIR
+fi
+
 WRAPPER_DIR="$(dirname "$0")"
 ZKG_PYZ="${WRAPPER_DIR}/../share/zkg/lib/zkg.pyz"
 


### PR DESCRIPTION
While this project has a perfectly fine `pyproject.toml` which allows
installing it with `pip`/`pipx`, we also shipped a `CMakeLists.txt` to
make the project installable when shipped as part of a bigger CMake
project like Zeek. The `install` rules we had were bare bones since they
only installed the top-level `zkg` script and the `zeekpkg` module it
depends on, but e.g., not any dependencies. It likely would also have
broken for potential future tweaks to `pyproject.toml` like switching to
another build backend.

This patch reworks our CMake install rules to install a fully
functioning version of this project instead. This allows users to use it
directly without having to install and manage dependencies themself.
This removes potential for user error (e.g., version mismatches) and
should also allow us to use dependency more freely/aggressively.

We accomplish this with `shiv` which leverages PEP441 to create
self-contained environments in zip files which can be loaded by any
Python interpreter >=python-3.4. Users invoke a small wrapper we create
which forwards to the top-level `zkg` script.