### PR TITLE
Protect state dir against concurrent operations

### DIFF
--- a/testing/tests/concurrent-state-lock
+++ b/testing/tests/concurrent-state-lock
@@ -1,0 +1,18 @@
+# @TEST-DOC: Concurrent zkg invocations must not race on shared state.
+#
+# @TEST-EXEC: bash %INPUT
+# @TEST-EXEC: btest-bg-wait 30
+#
+# @TEST-EXEC: test ! -s r1/.stderr
+# @TEST-EXEC: test ! -s r2/.stderr
+
+# `btest-bg-run` changes the working directory, so `zkg list` needs an explicit cd to find the test state.
+#
+# This test assumes `zkg list` mutates state, without that the race may not trigger.
+testdir=$(pwd)
+cat > run-zkg-list <<EOF
+cd $testdir && zkg list
+EOF
+
+BTEST_BG_RUN_SLEEP=0 btest-bg-run r1 "sh $testdir/run-zkg-list"
+BTEST_BG_RUN_SLEEP=0 btest-bg-run r2 "sh $testdir/run-zkg-list"

--- a/zeekpkg/manager.py
+++ b/zeekpkg/manager.py
@@ -5,6 +5,7 @@ methods to interact with and operate on Zeek packages.
 
 import configparser
 import copy
+import fcntl
 import filecmp
 import json
 import os
@@ -291,7 +292,13 @@ class Manager:
         self.manifest = os.path.join(self.state_dir, "manifest.json")
         self.autoload_script = os.path.join(self.script_dir, "packages.zeek")
         self.autoload_package = os.path.join(self.script_dir, "__load__.zeek")
+
         make_dir(self.state_dir)
+
+        # The lock file lives inside `state_dir`, so we open it after ensuring the dir exists.
+        self._state_lock = open(os.path.join(self.state_dir, ".lock"), "a")
+        fcntl.flock(self._state_lock, fcntl.LOCK_EX)
+
         make_dir(self.log_dir)
         make_dir(self.scratch_dir)
         make_dir(self.source_clonedir)


### PR DESCRIPTION
A big part of `zkg`'s work involves mutating its state dir, e.g., to update sources, refresh indices, or create temporary files. The code was built under the assumption that only a single `zkg` process would work on that state, so access was not controlled at all. This means that concurrent mutating operations against the state (of which we have many) could corrupt each other's expected state. Additionally, the functions we use to provide that functionality also do not cleanly cut along which part of the state they work on end to end making granular locking hard.

What this patch does instead is to protect access to the manager's global state through a lock. With that all `zkg` invocations are effectively sequenced and races are impossible. This makes concurrent `zkg` invocations potentially much slower, but `zkg` was never designed for that use case anyway.

We add a small test exercising concurrent, mutating access via `zkg list` which would have failed today without the lock, but it is not really clear that that operation would always perform state mutation.

This closes both #139 and maybe also #160 which could have had same underlying issue.
