### PR TITLE
Use local source tree for zkg in shiv command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(ZKG_PYZ "${CMAKE_CURRENT_BINARY_DIR}/zkg.pyz")
 add_custom_command(
   OUTPUT "${ZKG_PYZ}"
   COMMENT "Bundling zkg"
-  COMMAND "${SHIV}" -c zkg -o "${ZKG_PYZ}" zkg
+  COMMAND "${SHIV}" -c zkg -o "${ZKG_PYZ}" ${CMAKE_CURRENT_SOURCE_DIR}
   # TODO: Ideally this would also depend on anything in `zeekpkg/` changing.
   DEPENDS shiv_install pyproject.toml zkg
   VERBATIM)


### PR DESCRIPTION
In my local Zeek tree I swapped the `auxil/package-manager` submodule out for some of our current branch work, and after installing I noticed that the zkg version kept reporting
```
$ zkg --version
zkg 3.1.0
```
That is, the local version of zkg made no difference to the install. I think that's because simply passing `zkg` to shiv causes it to just pass that on to `pip install`, which then pulls it down from PyPI, where 3.1.0 is the latest.

The first thing I noticed was that I kept getting
```
Using cached zkg-3.1.0-py2.py3-none-any.whl (72 kB)
```
in the build, which I eventually tracked down to the contents of `~/.cache/pip` — not obvious. After blowing that away, I noticed it still did
```
Downloading zkg-3.1.0-py2.py3-none-any.whl (72 kB)
```
which eventually led me to this tweak after reading up on `shiv`. Seems to be working for me.

@bbannier fyi